### PR TITLE
Adding Pagination component

### DIFF
--- a/packages/strapi-design-system/src/Pagination/Pagination.js
+++ b/packages/strapi-design-system/src/Pagination/Pagination.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import { Row } from '../Row';
+import { PaginationContext } from './PaginationContext';
+
+const PaginationWrapper = styled.nav``;
+const PaginationList = styled(Row)`
+  & > * + * {
+    margin-left: ${({ theme }) => theme.spaces[1]};
+  }
+`;
+
+export const Pagination = ({ children, label, activePage }) => {
+  return (
+    <PaginationContext.Provider value={activePage}>
+      <PaginationWrapper aria-label={label}>
+        <PaginationList as="ul">{children}</PaginationList>
+      </PaginationWrapper>
+    </PaginationContext.Provider>
+  );
+};
+
+Pagination.defaultProps = {
+  label: 'pagination',
+};
+
+Pagination.propTypes = {
+  children: PropTypes.node.isRequired,
+  label: PropTypes.string,
+  activePage: PropTypes.number.isRequired,
+};

--- a/packages/strapi-design-system/src/Pagination/Pagination.stories.mdx
+++ b/packages/strapi-design-system/src/Pagination/Pagination.stories.mdx
@@ -1,0 +1,48 @@
+<!--- Pagination.stories.mdx --->
+
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { withDesign } from 'storybook-addon-designs';
+import { Pagination } from './Pagination';
+import { PreviousLink, NextLink, PageLink, Dots } from './components';
+
+<Meta
+  title="Pagination"
+  component={Pagination}
+  decorators={[withDesign]}
+  parameters={{
+    design: {
+      type: 'figma',
+      url: 'TODO: Fill the according figma file',
+    },
+  }}
+/>
+
+# Pagination
+
+This is the doc of the `Pagination` component
+
+## Pagination
+
+Description...
+
+<Canvas>
+  <Story name="base">
+    <Pagination activePage={2}>
+      <PreviousLink href="/1">Go to previous page</PreviousLink>
+      <PageLink number={1} href="/1">
+        Go to page 1
+      </PageLink>
+      <PageLink number={2} href="/2">
+        Go to page 2
+      </PageLink>
+      <Dots>And 23 other links</Dots>
+      <PageLink number={25} href="/25">
+        Go to page 3
+      </PageLink>
+      <PageLink number={26} href="/26">
+        Go to page 26
+      </PageLink>
+      <NextLink href="/3">Go to next page</NextLink>
+    </Pagination>
+  </Story>
+</Canvas>

--- a/packages/strapi-design-system/src/Pagination/PaginationContext.js
+++ b/packages/strapi-design-system/src/Pagination/PaginationContext.js
@@ -1,0 +1,4 @@
+import { createContext, useContext } from 'react';
+
+export const PaginationContext = createContext(1);
+export const useActivePage = () => useContext(PaginationContext);

--- a/packages/strapi-design-system/src/Pagination/__tests__/Pagination.e2e.js
+++ b/packages/strapi-design-system/src/Pagination/__tests__/Pagination.e2e.js
@@ -1,0 +1,13 @@
+import { injectAxe, checkA11y } from 'axe-playwright';
+
+describe('Pagination', () => {
+  beforeEach(async () => {
+    // This is the URL of the Storybook Iframe
+    await page.goto('http://localhost:6006/iframe.html?id=pagination--base&viewMode=story');
+    await injectAxe(page);
+  });
+
+  it('triggers axe on the document', async () => {
+    await checkA11y(page);
+  });
+});

--- a/packages/strapi-design-system/src/Pagination/__tests__/Pagination.spec.js
+++ b/packages/strapi-design-system/src/Pagination/__tests__/Pagination.spec.js
@@ -1,0 +1,242 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Pagination } from '../Pagination';
+import { PreviousLink, NextLink, PageLink, Dots } from '../components';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+
+describe('Pagination', () => {
+  it('snapshots the component', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Pagination activePage={2}>
+          <PreviousLink href="/1">Go to previous page</PreviousLink>
+          <PageLink number={1} href="/1">
+            Page 1
+          </PageLink>
+          <PageLink number={2} href="/2">
+            Page 2
+          </PageLink>
+          <PageLink number={3} href="/3">
+            Page 3
+          </PageLink>
+          <Dots>There are pages in between</Dots>
+          <PageLink number={4} href="/4">
+            Page 4
+          </PageLink>
+          <NextLink href="/3">Go to next page</NextLink>
+        </Pagination>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c0 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+      }
+
+      .c1 > * + * {
+        margin-left: 4px;
+      }
+
+      .c3 {
+        border: 0;
+        -webkit-clip: rect(0 0 0 0);
+        clip: rect(0 0 0 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+      }
+
+      .c4 {
+        font-weight: 400;
+        font-size: 0.75rem;
+        line-height: 1.33;
+      }
+
+      .c7 {
+        font-weight: 500;
+        font-size: 0.75rem;
+        line-height: 1.33;
+      }
+
+      .c2 {
+        padding: 12px;
+        background: #f6f6f9;
+        border-radius: 4px;
+        color: #32324d;
+        -webkit-text-decoration: none;
+        text-decoration: none;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+      }
+
+      .c6 {
+        padding: 12px;
+        background: #ffffff;
+        border-radius: 4px;
+        color: #4945ff;
+        box-shadow: 0px 1px 4px rgba(26,26,67,0.1);
+        -webkit-text-decoration: none;
+        text-decoration: none;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+      }
+
+      .c5 {
+        line-height: revert;
+      }
+
+      <nav
+        aria-label="pagination"
+        class=""
+      >
+        <ul
+          class="c0 c1"
+        >
+          <li>
+            <a
+              class="c2"
+              href="/1"
+            >
+              <div
+                class="c3"
+              >
+                Go to previous page
+              </div>
+              <img
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+            </a>
+          </li>
+          <li>
+            <a
+              aria-current="false"
+              class="c2"
+              href="/1"
+            >
+              <div
+                class="c3"
+              >
+                Page 1
+              </div>
+              <p
+                aria-hidden="true"
+                class="c4 c5"
+              >
+                1
+              </p>
+            </a>
+          </li>
+          <li>
+            <a
+              aria-current="true"
+              class="c6"
+              href="/2"
+            >
+              <div
+                class="c3"
+              >
+                Page 2
+              </div>
+              <p
+                aria-hidden="true"
+                class="c7 c5"
+              >
+                2
+              </p>
+            </a>
+          </li>
+          <li>
+            <a
+              aria-current="false"
+              class="c2"
+              href="/3"
+            >
+              <div
+                class="c3"
+              >
+                Page 3
+              </div>
+              <p
+                aria-hidden="true"
+                class="c4 c5"
+              >
+                3
+              </p>
+            </a>
+          </li>
+          <li>
+            <div
+              class="c2"
+            >
+              <div
+                class="c3"
+              >
+                There are pages in between
+              </div>
+              <p
+                aria-hidden="true"
+                class="c4 c5"
+              >
+                …
+              </p>
+            </div>
+          </li>
+          <li>
+            <a
+              aria-current="false"
+              class="c2"
+              href="/4"
+            >
+              <div
+                class="c3"
+              >
+                Page 4
+              </div>
+              <p
+                aria-hidden="true"
+                class="c4 c5"
+              >
+                4
+              </p>
+            </a>
+          </li>
+          <li>
+            <a
+              class="c2"
+              href="/3"
+            >
+              <div
+                class="c3"
+              >
+                Go to next page
+              </div>
+              <img
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+            </a>
+          </li>
+        </ul>
+      </nav>
+    `);
+  });
+});

--- a/packages/strapi-design-system/src/Pagination/assets/next.svg
+++ b/packages/strapi-design-system/src/Pagination/assets/next.svg
@@ -1,0 +1,3 @@
+<svg width="7" height="10" viewBox="0 0 7 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M-0.000195503 1.175L3.81647 5L-0.000195503 8.825L1.1748 10L6.1748 5L1.1748 0L-0.000195503 1.175Z" fill="#8E8EA9"/>
+</svg>

--- a/packages/strapi-design-system/src/Pagination/assets/previous.svg
+++ b/packages/strapi-design-system/src/Pagination/assets/previous.svg
@@ -1,0 +1,3 @@
+<svg width="7" height="10" viewBox="0 0 7 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.175 8.825L2.35833 5L6.175 1.175L5 0L0 5L5 10L6.175 8.825Z" fill="#8E8EA9"/>
+</svg>

--- a/packages/strapi-design-system/src/Pagination/components.js
+++ b/packages/strapi-design-system/src/Pagination/components.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+/** TODO: make sure to use the react component when they are available in strapi-icons */
+import prevLink from './assets/previous.svg';
+import nextLink from './assets/next.svg';
+import { VisuallyHidden } from '../VisuallyHidden';
+import { useActivePage } from './PaginationContext';
+import { Text } from '../Text';
+
+// TODO: make sure to use the Link exposed by the chosen router
+const Wrapper = styled.a`
+  padding: ${({ theme }) => theme.spaces[3]};
+  background: ${({ theme, active }) => (active ? theme.colors.neutral0 : theme.colors.neutral100)};
+  border-radius: ${({ theme }) => theme.borderRadius};
+  color: ${({ theme, active }) => (active ? theme.colors.primary600 : theme.colors.neutral800)};
+  box-shadow: ${({ active }) => (active ? `0px 1px 4px rgba(26, 26, 67, 0.1)` : undefined)};
+  text-decoration: none;
+  display: flex;
+`;
+
+const PaginationText = styled(Text)`
+  line-height: revert;
+`;
+
+export const PreviousLink = ({ children, ...props }) => (
+  <li>
+    <Wrapper {...props}>
+      <VisuallyHidden>{children}</VisuallyHidden>
+      <img src={prevLink} aria-hidden={true} />
+    </Wrapper>
+  </li>
+);
+
+export const NextLink = ({ children, ...props }) => (
+  <li>
+    <Wrapper {...props}>
+      <VisuallyHidden>{children}</VisuallyHidden>
+      <img src={nextLink} aria-hidden={true} />
+    </Wrapper>
+  </li>
+);
+
+export const PageLink = ({ number, children, ...props }) => {
+  const activePage = useActivePage();
+
+  const isActive = activePage === number;
+
+  return (
+    <li>
+      <Wrapper {...props} active={isActive} aria-current={isActive}>
+        <VisuallyHidden>{children}</VisuallyHidden>
+        <PaginationText aria-hidden={true} small={true} highlighted={isActive}>
+          {number}
+        </PaginationText>
+      </Wrapper>
+    </li>
+  );
+};
+
+export const Dots = ({ children, ...props }) => (
+  <li>
+    <Wrapper {...props} as="div">
+      <VisuallyHidden>{children}</VisuallyHidden>
+      <PaginationText aria-hidden={true} small={true}>
+        …
+      </PaginationText>
+    </Wrapper>
+  </li>
+);
+
+PageLink.propTypes = {
+  children: PropTypes.node.isRequired,
+  number: PropTypes.number.isRequired,
+};
+
+const sharedPropTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+Dots.propTypes = sharedPropTypes;
+NextLink.propTypes = sharedPropTypes;
+PreviousLink.propTypes = sharedPropTypes;

--- a/packages/strapi-design-system/src/Pagination/index.js
+++ b/packages/strapi-design-system/src/Pagination/index.js
@@ -1,0 +1,2 @@
+export * from './Pagination';
+export * from './components';


### PR DESCRIPTION
This PR brings the Pagination component to the table.

https://design-system-git-add-pagination-strapijs.vercel.app/?path=/story/pagination--base

NOTE: since we can't rely on strong values for the size of the element (32x32) I've tried my best to make it work using padding. Also notice that the size of the content will depend on its value (multiple characters will take more space)

Example:

## API

```jsx
<Pagination activePage={2}>
  <PreviousLink href="/1">Go to previous page</PreviousLink>
  <PageLink number={1} href="/1">
    Page 1
  </PageLink>
  <PageLink number={2} href="/2">
    Page 2
  </PageLink>
  <PageLink number={3} href="/3">
    Page 3
  </PageLink>
  <Dots>There are pages in between</Dots>
  <PageLink number={4} href="/4">
    Page 4
  </PageLink>
  <NextLink href="/3">Go to next page</NextLink>
</Pagination>
```

## Using VoiceOver

![2021-04-30 16 24 09](https://user-images.githubusercontent.com/3874873/116709260-cc407480-a9d0-11eb-81af-03617ea8025e.gif)
