### PR TITLE
Button component

### DIFF
--- a/packages/strapi-design-system/src/Button/Button.js
+++ b/packages/strapi-design-system/src/Button/Button.js
@@ -6,7 +6,7 @@ import { Box } from '../Box';
 import { getDisabledStyle, getHoverStyle, getActiveStyle, getVariantStyle, getIconPosition } from './utils';
 import { VARIANTS, BUTTON_SIZES } from './constants';
 
-export const ButtonStyle = styled.button`
+export const ButtonWrapper = styled.button`
   display: flex;
   cursor: pointer;
   padding: ${({ theme }) => `${theme.spaces[2]} ${theme.spaces[4]}`};
@@ -31,8 +31,9 @@ export const ButtonStyle = styled.button`
     }
   }
   &[aria-disabled='true'] {
+    pointer-events: none;
     ${getDisabledStyle}
-    &:hover {
+    &:active {
       ${getDisabledStyle}
     }
   }
@@ -47,11 +48,19 @@ export const ButtonStyle = styled.button`
 
 export const Button = ({ variant, leftIcon, rightIcon, disabled, children, size, ...props }) => {
   return (
-    <ButtonStyle aria-pressed={!disabled} aria-disabled={disabled} size={size} variant={variant} {...props}>
-      {leftIcon && <Box paddingRight={2}>{leftIcon}</Box>}
+    <ButtonWrapper aria-disabled={disabled} size={size} variant={variant} {...props}>
+      {leftIcon && (
+        <Box aria-hidden={true} paddingRight={2}>
+          {leftIcon}
+        </Box>
+      )}
       <Text small={size === 'S'}>{children}</Text>
-      {rightIcon && <Box paddingLeft={2}>{rightIcon}</Box>}
-    </ButtonStyle>
+      {rightIcon && (
+        <Box aria-hidden={true} paddingLeft={2}>
+          {rightIcon}
+        </Box>
+      )}
+    </ButtonWrapper>
   );
 };
 

--- a/packages/strapi-design-system/src/Button/Button.js
+++ b/packages/strapi-design-system/src/Button/Button.js
@@ -2,19 +2,33 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Text } from '../Text';
-import { getDisabledStyle, getHoverStyle, getActiveStyle, getVariantStyle } from './utils';
+import { Box } from '../Box';
+import { getDisabledStyle, getHoverStyle, getActiveStyle, getVariantStyle, getBoxPosition } from './utils';
 import { VARIANTS, BUTTON_SIZES } from './constants';
 
 export const ButtonStyle = styled.button`
+  display: flex;
+  cursor: pointer;
   padding: ${({ theme }) => `${theme.spaces[2]} ${theme.spaces[4]}`};
   border-radius: ${({ theme }) => theme.borderRadius};
   background: ${({ theme }) => theme.colors.primary600};
   border: none;
+  ${Box} {
+    display: flex;
+    align-items: center;
+    margin-top: ${getBoxPosition};
+  }
   ${Text} {
     color: ${({ theme }) => theme.colors.neutral0};
   }
-  > svg {
-    fill: ${({ theme }) => theme.colors.neutral0};
+  svg {
+    height: ${({ theme }) => theme.spaces[3]};
+  }
+  svg {
+    > g,
+    path {
+      fill: ${({ theme }) => theme.colors.neutral0};
+    }
   }
   &:disabled {
     ${getDisabledStyle}
@@ -33,10 +47,10 @@ export const ButtonStyle = styled.button`
 
 export const Button = ({ variant, leftIcon, rightIcon, children, size, ...props }) => {
   return (
-    <ButtonStyle variant={variant} {...props}>
-      {leftIcon && leftIcon}
+    <ButtonStyle size={size} variant={variant} {...props}>
+      {leftIcon && <Box paddingRight={2}>{leftIcon}</Box>}
       <Text small={size === 'S'}>{children}</Text>
-      {rightIcon && rightIcon}
+      {rightIcon && <Box paddingLeft={2}>{rightIcon}</Box>}
     </ButtonStyle>
   );
 };

--- a/packages/strapi-design-system/src/Button/Button.js
+++ b/packages/strapi-design-system/src/Button/Button.js
@@ -1,5 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { Text } from '../Text';
+import { getDisabledStyle, getHoverStyle, getActiveStyle, getVariantStyle } from './utils';
+import { VARIANTS, BUTTON_SIZES } from './constants';
 
-export const Button = styled.button`
-  background: ${(props) => props.theme.colors.primary100};
+export const ButtonStyle = styled.button`
+  padding: ${({ theme }) => `${theme.spaces[2]} ${theme.spaces[4]}`};
+  border-radius: ${({ theme }) => theme.borderRadius};
+  background: ${({ theme }) => theme.colors.primary600};
+  border: none;
+  ${Text} {
+    color: ${({ theme }) => theme.colors.neutral0};
+  }
+  > svg {
+    fill: ${({ theme }) => theme.colors.neutral0};
+  }
+  &:disabled {
+    ${getDisabledStyle}
+    &:hover {
+      ${getDisabledStyle}
+    }
+  }
+  &:hover {
+    ${getHoverStyle}
+  }
+  &:active {
+    ${getActiveStyle}
+  }
+  ${getVariantStyle}
 `;
+
+export const Button = ({ variant, leftIcon, rightIcon, children, size, ...props }) => {
+  return (
+    <ButtonStyle variant={variant} {...props}>
+      {leftIcon && leftIcon}
+      <Text small={size === 'S'}>{children}</Text>
+      {rightIcon && rightIcon}
+    </ButtonStyle>
+  );
+};
+
+Button.defaultProps = {
+  variant: 'default',
+  rightIcon: undefined,
+  leftIcon: undefined,
+  size: 'S',
+};
+Button.propTypes = {
+  rightIcon: PropTypes.element,
+  leftIcon: PropTypes.element,
+  children: PropTypes.string.isRequired,
+  variant: PropTypes.oneOf(VARIANTS),
+  size: PropTypes.oneOf(BUTTON_SIZES),
+};

--- a/packages/strapi-design-system/src/Button/Button.js
+++ b/packages/strapi-design-system/src/Button/Button.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Text } from '../Text';
 import { Box } from '../Box';
-import { getDisabledStyle, getHoverStyle, getActiveStyle, getVariantStyle, getBoxPosition } from './utils';
+import { getDisabledStyle, getHoverStyle, getActiveStyle, getVariantStyle, getIconPosition } from './utils';
 import { VARIANTS, BUTTON_SIZES } from './constants';
 
 export const ButtonStyle = styled.button`
@@ -16,7 +16,7 @@ export const ButtonStyle = styled.button`
   ${Box} {
     display: flex;
     align-items: center;
-    margin-top: ${getBoxPosition};
+    margin-top: ${getIconPosition};
   }
   ${Text} {
     color: ${({ theme }) => theme.colors.neutral0};
@@ -30,7 +30,7 @@ export const ButtonStyle = styled.button`
       fill: ${({ theme }) => theme.colors.neutral0};
     }
   }
-  &:disabled {
+  &[aria-disabled='true'] {
     ${getDisabledStyle}
     &:hover {
       ${getDisabledStyle}
@@ -45,9 +45,9 @@ export const ButtonStyle = styled.button`
   ${getVariantStyle}
 `;
 
-export const Button = ({ variant, leftIcon, rightIcon, children, size, ...props }) => {
+export const Button = ({ variant, leftIcon, rightIcon, disabled, children, size, ...props }) => {
   return (
-    <ButtonStyle size={size} variant={variant} {...props}>
+    <ButtonStyle aria-pressed={!disabled} aria-disabled={disabled} size={size} variant={variant} {...props}>
       {leftIcon && <Box paddingRight={2}>{leftIcon}</Box>}
       <Text small={size === 'S'}>{children}</Text>
       {rightIcon && <Box paddingLeft={2}>{rightIcon}</Box>}
@@ -56,15 +56,17 @@ export const Button = ({ variant, leftIcon, rightIcon, children, size, ...props 
 };
 
 Button.defaultProps = {
-  variant: 'default',
-  rightIcon: undefined,
+  disabled: false,
   leftIcon: undefined,
+  rightIcon: undefined,
   size: 'S',
+  variant: 'default',
 };
 Button.propTypes = {
-  rightIcon: PropTypes.element,
-  leftIcon: PropTypes.element,
   children: PropTypes.string.isRequired,
-  variant: PropTypes.oneOf(VARIANTS),
+  disabled: PropTypes.bool,
+  leftIcon: PropTypes.element,
+  rightIcon: PropTypes.element,
   size: PropTypes.oneOf(BUTTON_SIZES),
+  variant: PropTypes.oneOf(VARIANTS),
 };

--- a/packages/strapi-design-system/src/Button/Button.stories.mdx
+++ b/packages/strapi-design-system/src/Button/Button.stories.mdx
@@ -3,6 +3,7 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import { withDesign } from 'storybook-addon-designs';
 import { Button } from './Button';
+import { Box } from '../Box';
 
 <Meta
   title="Button"
@@ -11,7 +12,7 @@ import { Button } from './Button';
   parameters={{
     design: {
       type: 'figma',
-      url: process.env.FIGMA_BUTTON_URL,
+      url: 'https://www.figma.com/file/PICiE8O4NLrHO1lhJftLdE/Design-System-%E2%9C%85?node-id=866%3A481',
     },
   }}
 />
@@ -20,22 +21,26 @@ import { Button } from './Button';
 
 This is the doc of the `button` component
 
-## Button
+## Variants
 
 Description...
 
 <Canvas>
-  <Story name="base">
-    <Button>Hello world</Button>
+  <Story name="variants">
+    {['default', 'secondary', 'tertiary', 'success', 'danger', 'success-light', 'danger-light'].map((variant) => (
+      <Box key={variant} paddingBottom={2}>
+        <Button variant={variant}>{variant}</Button>
+      </Box>
+    ))}
   </Story>
 </Canvas>
 
-## Button check
+## Disabled
 
-Other story description...
+Description...
 
 <Canvas>
-  <Story name="with icon">
-    <Button>with icon</Button>
+  <Story name="disabled">
+    <Button disabled>Disabled</Button>
   </Story>
 </Canvas>

--- a/packages/strapi-design-system/src/Button/Button.stories.mdx
+++ b/packages/strapi-design-system/src/Button/Button.stories.mdx
@@ -45,7 +45,7 @@ Description...
     <Box paddingBottom={2}>
       <Button disabled>Disabled</Button>
     </Box>
-    <Button leftIcon={<ContentIcon />} disabled>
+    <Button onClick={e => console.log(e)} leftIcon={<ContentIcon />} disabled>
       Disabled
     </Button>
   </Story>

--- a/packages/strapi-design-system/src/Button/Button.stories.mdx
+++ b/packages/strapi-design-system/src/Button/Button.stories.mdx
@@ -2,6 +2,7 @@
 
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import { withDesign } from 'storybook-addon-designs';
+import { HelpIcon, ContentIcon, Ct } from '@strapi/icons';
 import { Button } from './Button';
 import { Box } from '../Box';
 
@@ -29,7 +30,7 @@ Description...
   <Story name="variants">
     {['default', 'secondary', 'tertiary', 'success', 'danger', 'success-light', 'danger-light'].map((variant) => (
       <Box key={variant} paddingBottom={2}>
-        <Button variant={variant}>{variant}</Button>
+        <Button onClick={e => console.log(e)} variant={variant}>{variant}</Button>
       </Box>
     ))}
   </Story>
@@ -41,6 +42,34 @@ Description...
 
 <Canvas>
   <Story name="disabled">
-    <Button disabled>Disabled</Button>
+    <Box paddingBottom={2}>
+      <Button disabled>Disabled</Button>
+    </Box>
+    <Button leftIcon={<ContentIcon />} disabled>
+      Disabled
+    </Button>
+  </Story>
+</Canvas>
+
+## With icon
+
+Description...
+
+<Canvas>
+  <Story name="with-icon">
+    <Box paddingBottom={2}>
+      <Button leftIcon={<ContentIcon />}>Content type</Button>
+    </Box>
+    <Button rightIcon={<HelpIcon />}>Help</Button>
+  </Story>
+</Canvas>
+
+## L size
+
+Description...
+
+<Canvas>
+  <Story name="lsize">
+      <Button size='L' leftIcon={<ContentIcon />}>Content type</Button>
   </Story>
 </Canvas>

--- a/packages/strapi-design-system/src/Button/__tests__/Button.e2e.js
+++ b/packages/strapi-design-system/src/Button/__tests__/Button.e2e.js
@@ -3,25 +3,8 @@ import { injectAxe, checkA11y } from 'axe-playwright';
 describe('Button', () => {
   beforeAll(async () => {
     // This is the URL of the Storybook Iframe
-    await page.goto('http://localhost:6006/iframe.html?id=button--base&viewMode=story');
+    await page.goto('http://localhost:6006/iframe.html?id=button--variants&viewMode=story');
     await injectAxe(page);
-  });
-
-  it('snapshots the AxTree', async () => {
-    const button = await page.waitForSelector('text="Hello world"');
-    const axTreeSnapshot = await page.accessibility.snapshot({ root: button });
-
-    expect(await button.textContent()).toContain('Hello world');
-    expect(axTreeSnapshot).toMatchInlineSnapshot(`
-            Object {
-              "checked": undefined,
-              "children": undefined,
-              "name": "Hello world",
-              "pressed": undefined,
-              "role": "button",
-              "value": undefined,
-            }
-        `);
   });
 
   it('triggers axe on the document', async () => {

--- a/packages/strapi-design-system/src/Button/__tests__/Button.spec.js
+++ b/packages/strapi-design-system/src/Button/__tests__/Button.spec.js
@@ -5,7 +5,7 @@ import { ThemeProvider } from '../../ThemeProvider';
 import { lightTheme } from '../../themes';
 
 describe('Button', () => {
-  it('matches snapshot', () => {
+  it('matches snapshot of the default variant', () => {
     const { container } = render(
       <ThemeProvider theme={lightTheme}>
         <Button>Hello world</Button>
@@ -58,33 +58,32 @@ describe('Button', () => {
         fill: #ffffff;
       }
 
-      .c0:disabled {
-        cursor: unset;
+      .c0[aria-disabled='true'] {
+        pointer-events: none;
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c0:disabled .c1 {
+      .c0[aria-disabled='true'] .c1 {
         color: #8e8ea9;
       }
 
-      .c0:disabled svg > g,
-      .c0:disabled svg path {
+      .c0[aria-disabled='true'] svg > g,
+      .c0[aria-disabled='true'] svg path {
         fill: #8e8ea9;
       }
 
-      .c0:disabled:hover {
-        cursor: unset;
+      .c0[aria-disabled='true']:active {
         border: 1px solid #dcdce4;
         background: #eaeaef;
       }
 
-      .c0:disabled:hover .c1 {
+      .c0[aria-disabled='true']:active .c1 {
         color: #8e8ea9;
       }
 
-      .c0:disabled:hover svg > g,
-      .c0:disabled:hover svg path {
+      .c0[aria-disabled='true']:active svg > g,
+      .c0[aria-disabled='true']:active svg path {
         fill: #8e8ea9;
       }
 
@@ -97,12 +96,463 @@ describe('Button', () => {
       }
 
       <button
+        aria-disabled="false"
         class="c0"
       >
         <p
           class="c1 c2"
         >
           Hello world
+        </p>
+      </button>
+    `);
+  });
+
+  it('matches snapshot of the secondary variant', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Button variant="secondary">Submit</Button>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c2 {
+        font-weight: 400;
+        font-size: 0.75rem;
+        line-height: 1.33;
+      }
+
+      .c0 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        cursor: pointer;
+        padding: 8px 16px;
+        border-radius: 4px;
+        background: #4945ff;
+        border: none;
+        border: 1px solid #d9d8ff;
+        background: #f0f0ff;
+      }
+
+      .c0 .sc-iCfLBT {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+        margin-top: 1px;
+      }
+
+      .c0 .c1 {
+        color: #ffffff;
+      }
+
+      .c0 svg {
+        height: 12px;
+      }
+
+      .c0 svg > g,
+      .c0 svg path {
+        fill: #ffffff;
+      }
+
+      .c0[aria-disabled='true'] {
+        pointer-events: none;
+        border: 1px solid #dcdce4;
+        background: #eaeaef;
+      }
+
+      .c0[aria-disabled='true'] .c1 {
+        color: #8e8ea9;
+      }
+
+      .c0[aria-disabled='true'] svg > g,
+      .c0[aria-disabled='true'] svg path {
+        fill: #8e8ea9;
+      }
+
+      .c0[aria-disabled='true']:active {
+        border: 1px solid #dcdce4;
+        background: #eaeaef;
+      }
+
+      .c0[aria-disabled='true']:active .c1 {
+        color: #8e8ea9;
+      }
+
+      .c0[aria-disabled='true']:active svg > g,
+      .c0[aria-disabled='true']:active svg path {
+        fill: #8e8ea9;
+      }
+
+      .c0:hover {
+        background-color: #ffffff;
+      }
+
+      .c0:active {
+        background-color: #ffffff;
+        border: 1px solid #4945ff;
+      }
+
+      .c0:active .c1 {
+        color: #4945ff;
+      }
+
+      .c0:active svg > g,
+      .c0:active svg path {
+        fill: #4945ff;
+      }
+
+      .c0 .c1 {
+        color: #271fe0;
+      }
+
+      .c0 svg > g,
+      .c0 svg path {
+        fill: #271fe0;
+      }
+
+      <button
+        aria-disabled="false"
+        class="c0"
+      >
+        <p
+          class="c1 c2"
+        >
+          Submit
+        </p>
+      </button>
+    `);
+  });
+
+  it('matches snapshot of the success variant', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Button variant="success">Success</Button>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c2 {
+        font-weight: 400;
+        font-size: 0.75rem;
+        line-height: 1.33;
+      }
+
+      .c0 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        cursor: pointer;
+        padding: 8px 16px;
+        border-radius: 4px;
+        background: #4945ff;
+        border: none;
+        border: 1px solid #338648;
+        background: #338648;
+      }
+
+      .c0 .sc-iCfLBT {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+        margin-top: 1px;
+      }
+
+      .c0 .c1 {
+        color: #ffffff;
+      }
+
+      .c0 svg {
+        height: 12px;
+      }
+
+      .c0 svg > g,
+      .c0 svg path {
+        fill: #ffffff;
+      }
+
+      .c0[aria-disabled='true'] {
+        pointer-events: none;
+        border: 1px solid #dcdce4;
+        background: #eaeaef;
+      }
+
+      .c0[aria-disabled='true'] .c1 {
+        color: #8e8ea9;
+      }
+
+      .c0[aria-disabled='true'] svg > g,
+      .c0[aria-disabled='true'] svg path {
+        fill: #8e8ea9;
+      }
+
+      .c0[aria-disabled='true']:active {
+        border: 1px solid #dcdce4;
+        background: #eaeaef;
+      }
+
+      .c0[aria-disabled='true']:active .c1 {
+        color: #8e8ea9;
+      }
+
+      .c0[aria-disabled='true']:active svg > g,
+      .c0[aria-disabled='true']:active svg path {
+        fill: #8e8ea9;
+      }
+
+      .c0:hover {
+        background: #5cb176;
+      }
+
+      .c0:active {
+        background: #338648;
+      }
+
+      <button
+        aria-disabled="false"
+        class="c0"
+      >
+        <p
+          class="c1 c2"
+        >
+          Success
+        </p>
+      </button>
+    `);
+  });
+
+  it('matches snapshot of the danger-light variant', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Button variant="danger-light">Remove</Button>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c2 {
+        font-weight: 400;
+        font-size: 0.75rem;
+        line-height: 1.33;
+      }
+
+      .c0 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        cursor: pointer;
+        padding: 8px 16px;
+        border-radius: 4px;
+        background: #4945ff;
+        border: none;
+        border: 1px solid #f5c0b8;
+        background: #fcecea;
+      }
+
+      .c0 .sc-iCfLBT {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+        margin-top: 1px;
+      }
+
+      .c0 .c1 {
+        color: #ffffff;
+      }
+
+      .c0 svg {
+        height: 12px;
+      }
+
+      .c0 svg > g,
+      .c0 svg path {
+        fill: #ffffff;
+      }
+
+      .c0[aria-disabled='true'] {
+        pointer-events: none;
+        border: 1px solid #dcdce4;
+        background: #eaeaef;
+      }
+
+      .c0[aria-disabled='true'] .c1 {
+        color: #8e8ea9;
+      }
+
+      .c0[aria-disabled='true'] svg > g,
+      .c0[aria-disabled='true'] svg path {
+        fill: #8e8ea9;
+      }
+
+      .c0[aria-disabled='true']:active {
+        border: 1px solid #dcdce4;
+        background: #eaeaef;
+      }
+
+      .c0[aria-disabled='true']:active .c1 {
+        color: #8e8ea9;
+      }
+
+      .c0[aria-disabled='true']:active svg > g,
+      .c0[aria-disabled='true']:active svg path {
+        fill: #8e8ea9;
+      }
+
+      .c0:hover {
+        background-color: #ffffff;
+      }
+
+      .c0:active {
+        background-color: #ffffff;
+        border: 1px solid #dd2b23;
+      }
+
+      .c0:active .c1 {
+        color: #dd2b23;
+      }
+
+      .c0:active svg > g,
+      .c0:active svg path {
+        fill: #dd2b23;
+      }
+
+      .c0 .c1 {
+        color: #b72b1a;
+      }
+
+      .c0 svg > g,
+      .c0 svg path {
+        fill: #b72b1a;
+      }
+
+      <button
+        aria-disabled="false"
+        class="c0"
+      >
+        <p
+          class="c1 c2"
+        >
+          Remove
+        </p>
+      </button>
+    `);
+  });
+
+  it('matches snapshot of the L size button', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Button size="L">Button</Button>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c2 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+      }
+
+      .c0 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        cursor: pointer;
+        padding: 8px 16px;
+        border-radius: 4px;
+        background: #4945ff;
+        border: none;
+        border: 1px solid #4945ff;
+        background: #4945ff;
+      }
+
+      .c0 .sc-iCfLBT {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+        margin-top: 3px;
+      }
+
+      .c0 .c1 {
+        color: #ffffff;
+      }
+
+      .c0 svg {
+        height: 12px;
+      }
+
+      .c0 svg > g,
+      .c0 svg path {
+        fill: #ffffff;
+      }
+
+      .c0[aria-disabled='true'] {
+        pointer-events: none;
+        border: 1px solid #dcdce4;
+        background: #eaeaef;
+      }
+
+      .c0[aria-disabled='true'] .c1 {
+        color: #8e8ea9;
+      }
+
+      .c0[aria-disabled='true'] svg > g,
+      .c0[aria-disabled='true'] svg path {
+        fill: #8e8ea9;
+      }
+
+      .c0[aria-disabled='true']:active {
+        border: 1px solid #dcdce4;
+        background: #eaeaef;
+      }
+
+      .c0[aria-disabled='true']:active .c1 {
+        color: #8e8ea9;
+      }
+
+      .c0[aria-disabled='true']:active svg > g,
+      .c0[aria-disabled='true']:active svg path {
+        fill: #8e8ea9;
+      }
+
+      .c0:hover {
+        background: #7b79ff;
+      }
+
+      .c0:active {
+        background: #4945ff;
+      }
+
+      <button
+        aria-disabled="false"
+        class="c0"
+      >
+        <p
+          class="c1 c2"
+        >
+          Button
         </p>
       </button>
     `);

--- a/packages/strapi-design-system/src/Button/__tests__/Button.spec.js
+++ b/packages/strapi-design-system/src/Button/__tests__/Button.spec.js
@@ -13,14 +13,97 @@ describe('Button', () => {
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
+      .c2 {
+        font-weight: 400;
+        font-size: 0.75rem;
+        line-height: 1.33;
+      }
+
       .c0 {
-        background: #f0f0ff;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        cursor: pointer;
+        padding: 8px 16px;
+        border-radius: 4px;
+        background: #4945ff;
+        border: none;
+        border: 1px solid #4945ff;
+        background: #4945ff;
+      }
+
+      .c0 .sc-iCfLBT {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+        margin-top: 1px;
+      }
+
+      .c0 .c1 {
+        color: #ffffff;
+      }
+
+      .c0 svg {
+        height: 12px;
+      }
+
+      .c0 svg > g,
+      .c0 svg path {
+        fill: #ffffff;
+      }
+
+      .c0:disabled {
+        cursor: unset;
+        border: 1px solid #dcdce4;
+        background: #eaeaef;
+      }
+
+      .c0:disabled .c1 {
+        color: #8e8ea9;
+      }
+
+      .c0:disabled svg > g,
+      .c0:disabled svg path {
+        fill: #8e8ea9;
+      }
+
+      .c0:disabled:hover {
+        cursor: unset;
+        border: 1px solid #dcdce4;
+        background: #eaeaef;
+      }
+
+      .c0:disabled:hover .c1 {
+        color: #8e8ea9;
+      }
+
+      .c0:disabled:hover svg > g,
+      .c0:disabled:hover svg path {
+        fill: #8e8ea9;
+      }
+
+      .c0:hover {
+        background: #7b79ff;
+      }
+
+      .c0:active {
+        background: #4945ff;
       }
 
       <button
         class="c0"
       >
-        Hello world
+        <p
+          class="c1 c2"
+        >
+          Hello world
+        </p>
       </button>
     `);
   });

--- a/packages/strapi-design-system/src/Button/__tests__/utils.spec.js
+++ b/packages/strapi-design-system/src/Button/__tests__/utils.spec.js
@@ -1,0 +1,19 @@
+import { getVariantColorName } from '../utils';
+
+describe('utils', () => {
+  describe('getVariantsColorName', () => {
+    it('should return primary for the default and secondary', () => {
+      expect(getVariantColorName('default')).toEqual('primary');
+      expect(getVariantColorName('secondary')).toEqual('primary');
+    });
+
+    it('should return the right color name for light variants', () => {
+      expect(getVariantColorName('success-light')).toEqual('success');
+      expect(getVariantColorName('danger-light')).toEqual('danger');
+    });
+
+    it('should return primary by default', () => {
+      expect(getVariantColorName('unknown')).toEqual('primary');
+    });
+  });
+});

--- a/packages/strapi-design-system/src/Button/constants.js
+++ b/packages/strapi-design-system/src/Button/constants.js
@@ -1,0 +1,3 @@
+export const LIGHT_VARIANTS = ['success-light', 'danger-light'];
+export const VARIANTS = ['default', 'tertiary', 'secondary', 'danger', 'success', ...LIGHT_VARIANTS];
+export const BUTTON_SIZES = ['S', 'L', 'XL'];

--- a/packages/strapi-design-system/src/Button/constants.js
+++ b/packages/strapi-design-system/src/Button/constants.js
@@ -1,3 +1,3 @@
 export const LIGHT_VARIANTS = ['success-light', 'danger-light'];
 export const VARIANTS = ['default', 'tertiary', 'secondary', 'danger', 'success', ...LIGHT_VARIANTS];
-export const BUTTON_SIZES = ['S', 'L', 'XL'];
+export const BUTTON_SIZES = ['S', 'L'];

--- a/packages/strapi-design-system/src/Button/utils.js
+++ b/packages/strapi-design-system/src/Button/utils.js
@@ -2,7 +2,7 @@ import { Text } from '../Text';
 import { LIGHT_VARIANTS } from './constants';
 
 export const getVariantColorName = (variant) => {
-  if (variant.includes('-light')) {
+  if (LIGHT_VARIANTS.includes(variant)) {
     return variant.substring(0, variant.lastIndexOf('-'));
   }
   if (variant === 'tertiary') {
@@ -17,13 +17,16 @@ export const getVariantColorName = (variant) => {
 
 export const getDisabledStyle = ({ theme }) => {
   return `
+    cursor: unset;
     border: 1px solid ${theme.colors.neutral200};
     background: ${theme.colors.neutral150};
     ${Text} {
       color: ${theme.colors.neutral500};
     }
-    > svg {
-      fill: ${theme.colors.neutral500};
+    svg {
+      > g, path {
+        fill: ${theme.colors.neutral500};
+      }
     }
   `;
 };
@@ -53,6 +56,11 @@ export const getActiveStyle = ({ theme, variant }) => {
       ${Text} {
         color: ${theme.colors[`${getVariantColorName(variant)}600`]};
       }
+      svg {
+        > g, path {
+          fill: ${theme.colors[`${getVariantColorName(variant)}600`]};
+        }
+      }
     `;
   }
   if (variant === 'tertiary') {
@@ -75,10 +83,12 @@ export const getVariantStyle = ({ theme, variant }) => {
           border: 1px solid ${theme.colors[`${getVariantColorName(variant)}200`]};
           background: ${theme.colors[`${getVariantColorName(variant)}100`]};
           ${Text} {
-            color: ${theme.colors[`${getVariantColorName(variant)}600`]}
+            color: ${theme.colors[`${getVariantColorName(variant)}700`]};
           }
-          > svg {
-            fill: ${theme.colors[`${getVariantColorName(variant)}600`]}
+          svg {
+            > g, path {
+              fill: ${theme.colors[`${getVariantColorName(variant)}700`]};
+            }
           }
         `;
     }
@@ -87,17 +97,28 @@ export const getVariantStyle = ({ theme, variant }) => {
           border: 1px solid ${theme.colors.neutral200};
           background: ${theme.colors.neutral0};
           ${Text} {
-            color: ${theme.colors.neutral800}
+            color: ${theme.colors.neutral800};
           }
-          > svg {
-            fill: ${theme.colors.neutral800}
+          svg {
+            > g, path {
+              fill: ${theme.colors.neutral800};
+            }
           }
         `;
     }
     default: {
       return `
+          border: 1px solid ${theme.colors[`${getVariantColorName(variant)}600`]};
           background: ${theme.colors[`${getVariantColorName(variant)}600`]};
         `;
     }
   }
+};
+
+export const getBoxPosition = ({ size }) => {
+  if (size === 'S') {
+    return '1px';
+  }
+
+  return '3px';
 };

--- a/packages/strapi-design-system/src/Button/utils.js
+++ b/packages/strapi-design-system/src/Button/utils.js
@@ -1,0 +1,103 @@
+import { Text } from '../Text';
+import { LIGHT_VARIANTS } from './constants';
+
+export const getVariantColorName = (variant) => {
+  if (variant.includes('-light')) {
+    return variant.substring(0, variant.lastIndexOf('-'));
+  }
+  if (variant === 'tertiary') {
+    return 'neutral';
+  }
+  if (['default', 'secondary'].includes(variant)) {
+    return 'primary';
+  }
+
+  return variant;
+};
+
+export const getDisabledStyle = ({ theme }) => {
+  return `
+    border: 1px solid ${theme.colors.neutral200};
+    background: ${theme.colors.neutral150};
+    ${Text} {
+      color: ${theme.colors.neutral500};
+    }
+    > svg {
+      fill: ${theme.colors.neutral500};
+    }
+  `;
+};
+
+export const getHoverStyle = ({ theme, variant }) => {
+  if ([...LIGHT_VARIANTS, 'secondary'].includes(variant)) {
+    return `
+      background-color: ${theme.colors.neutral0};
+    `;
+  }
+  if (variant === 'tertiary') {
+    return `
+      background-color: ${theme.colors.neutral100};
+    `;
+  }
+
+  return `
+    background: ${theme.colors[`${getVariantColorName(variant)}500`]};
+  `;
+};
+
+export const getActiveStyle = ({ theme, variant }) => {
+  if ([...LIGHT_VARIANTS, 'secondary'].includes(variant)) {
+    return `
+      background-color: ${theme.colors.neutral0};
+      border: 1px solid ${theme.colors[`${getVariantColorName(variant)}600`]};
+      ${Text} {
+        color: ${theme.colors[`${getVariantColorName(variant)}600`]};
+      }
+    `;
+  }
+  if (variant === 'tertiary') {
+    return `
+      background-color: ${theme.colors.neutral150};
+    `;
+  }
+
+  return `
+    background: ${theme.colors[`${getVariantColorName(variant)}600`]};
+  `;
+};
+
+export const getVariantStyle = ({ theme, variant }) => {
+  switch (variant) {
+    case 'danger-light':
+    case 'success-light':
+    case 'secondary': {
+      return `
+          border: 1px solid ${theme.colors[`${getVariantColorName(variant)}200`]};
+          background: ${theme.colors[`${getVariantColorName(variant)}100`]};
+          ${Text} {
+            color: ${theme.colors[`${getVariantColorName(variant)}600`]}
+          }
+          > svg {
+            fill: ${theme.colors[`${getVariantColorName(variant)}600`]}
+          }
+        `;
+    }
+    case 'tertiary': {
+      return `
+          border: 1px solid ${theme.colors.neutral200};
+          background: ${theme.colors.neutral0};
+          ${Text} {
+            color: ${theme.colors.neutral800}
+          }
+          > svg {
+            fill: ${theme.colors.neutral800}
+          }
+        `;
+    }
+    default: {
+      return `
+          background: ${theme.colors[`${getVariantColorName(variant)}600`]};
+        `;
+    }
+  }
+};

--- a/packages/strapi-design-system/src/Button/utils.js
+++ b/packages/strapi-design-system/src/Button/utils.js
@@ -1,5 +1,5 @@
 import { Text } from '../Text';
-import { LIGHT_VARIANTS } from './constants';
+import { LIGHT_VARIANTS, VARIANTS } from './constants';
 
 export const getVariantColorName = (variant) => {
   if (LIGHT_VARIANTS.includes(variant)) {
@@ -8,7 +8,7 @@ export const getVariantColorName = (variant) => {
   if (variant === 'tertiary') {
     return 'neutral';
   }
-  if (['default', 'secondary'].includes(variant)) {
+  if (['default', 'secondary'].includes(variant) || !VARIANTS.includes(variant)) {
     return 'primary';
   }
 
@@ -17,8 +17,6 @@ export const getVariantColorName = (variant) => {
 
 export const getDisabledStyle = ({ theme }) => {
   return `
-    cursor: unset;
-    pointer-events: none;
     border: 1px solid ${theme.colors.neutral200};
     background: ${theme.colors.neutral150};
     ${Text} {

--- a/packages/strapi-design-system/src/Button/utils.js
+++ b/packages/strapi-design-system/src/Button/utils.js
@@ -18,6 +18,7 @@ export const getVariantColorName = (variant) => {
 export const getDisabledStyle = ({ theme }) => {
   return `
     cursor: unset;
+    pointer-events: none;
     border: 1px solid ${theme.colors.neutral200};
     background: ${theme.colors.neutral150};
     ${Text} {
@@ -115,7 +116,7 @@ export const getVariantStyle = ({ theme, variant }) => {
   }
 };
 
-export const getBoxPosition = ({ size }) => {
+export const getIconPosition = ({ size }) => {
   if (size === 'S') {
     return '1px';
   }

--- a/packages/strapi-design-system/src/Loader/__tests__/Loader.spec.js
+++ b/packages/strapi-design-system/src/Loader/__tests__/Loader.spec.js
@@ -8,21 +8,40 @@ describe('Loader', () => {
   it('snapshots the component', () => {
     const { container } = render(
       <ThemeProvider theme={lightTheme}>
-        <Loader />
+        <Loader>Loading content...</Loader>
       </ThemeProvider>,
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
+      .c0 {
+        border: 0;
+        -webkit-clip: rect(0 0 0 0);
+        clip: rect(0 0 0 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+      }
+
+      .c1 {
+        -webkit-animation: gzYjWD 1s infinite linear;
+        animation: gzYjWD 1s infinite linear;
+      }
+
       <div
         aria-live="assertive"
         role="alert"
       >
         <div
-          class="sc-bdfBwQ eDhJsz"
-        />
+          class="c0"
+        >
+          Loading content...
+        </div>
         <img
           aria-hidden="true"
-          class="sc-gsTCUz eusWxo"
+          class="c1"
           src="test-file-stub"
         />
       </div>


### PR DESCRIPTION
Add a button component

Example on: https://design-system-git-atom-button-strapijs.vercel.app/?path=/story/button--variants

## API

Existing variants : `['default', 'tertiary', 'secondary', 'danger', 'success', 'success-light', 'danger-light'];`
Existing sizes : `S, L`
```jsx
<Button size="L" onClick={handler} aria-label="Create something">
   Create
</Button>
```

With icon
```jsx
import { Plus, Trash } from '@strapi/icons';
 
<Button aria-label="New row" leftIcon={<Plus />} rightIcon={<Trash />}>
   New row
</Button>
```

## Voiceover

![buttonvoice](https://user-images.githubusercontent.com/7756284/116870752-62fc7380-ac13-11eb-8027-fc3f69958a9c.gif)

Signed-off-by: HichamELBSI <elabbassih@gmail.com>