### PR TITLE
Add progressbar

### DIFF
--- a/packages/strapi-design-system/.eslintrc.js
+++ b/packages/strapi-design-system/.eslintrc.js
@@ -15,4 +15,7 @@ module.exports = {
     'plugin:react/recommended', // Uses the recommended rules from @eslint-plugin-react
     'plugin:prettier/recommended', // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
   ],
+  rules: {
+    'react/sort-prop-types': 1,
+  },
 };

--- a/packages/strapi-design-system/src/BaseRadio/RadioGroup.js
+++ b/packages/strapi-design-system/src/BaseRadio/RadioGroup.js
@@ -29,8 +29,8 @@ RadioGroup.defaultProps = {
 RadioGroup.propTypes = {
   children: PropTypes.node.isRequired,
   labelledBy: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-  value: PropTypes.string,
-  size: PropTypes.oneOf(['M', 'L']),
   name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  size: PropTypes.oneOf(['M', 'L']),
+  value: PropTypes.string,
 };

--- a/packages/strapi-design-system/src/Box/Box.js
+++ b/packages/strapi-design-system/src/Box/Box.js
@@ -43,13 +43,13 @@ Box.defaultProps = {
 };
 
 Box.propTypes = {
-  children: PropTypes.node.isRequired,
   background: PropTypes.string,
+  children: PropTypes.node.isRequired,
   color: PropTypes.string,
+  hasRadius: PropTypes.bool,
   padding: PropTypes.number,
-  paddingTop: PropTypes.number,
-  paddingRight: PropTypes.number,
   paddingBottom: PropTypes.number,
   paddingLeft: PropTypes.number,
-  hasRadius: PropTypes.bool,
+  paddingRight: PropTypes.number,
+  paddingTop: PropTypes.number,
 };

--- a/packages/strapi-design-system/src/Field/Field.js
+++ b/packages/strapi-design-system/src/Field/Field.js
@@ -20,7 +20,7 @@ Field.defaultProps = {
 
 Field.propTypes = {
   children: PropTypes.node.isRequired,
-  name: PropTypes.string.isRequired,
   error: PropTypes.string,
   hint: PropTypes.string,
+  name: PropTypes.string.isRequired,
 };

--- a/packages/strapi-design-system/src/Grid/Grid.js
+++ b/packages/strapi-design-system/src/Grid/Grid.js
@@ -33,8 +33,8 @@ export const Grid = styled(Box)`
 Grid.displayName = 'Grid';
 
 Grid.propTypes = {
-  cols: PropTypes.string,
-  rows: PropTypes.string,
-  gap: PropTypes.oneOfType([PropTypes.number, PropTypes.arrayOf(PropTypes.number)]),
   areas: PropTypes.arrayOf(PropTypes.string),
+  cols: PropTypes.string,
+  gap: PropTypes.oneOfType([PropTypes.number, PropTypes.arrayOf(PropTypes.number)]),
+  rows: PropTypes.string,
 };

--- a/packages/strapi-design-system/src/Loader/__tests__/Loader.spec.js
+++ b/packages/strapi-design-system/src/Loader/__tests__/Loader.spec.js
@@ -8,7 +8,11 @@ describe('Loader', () => {
   it('snapshots the component', () => {
     const { container } = render(
       <ThemeProvider theme={lightTheme}>
+<<<<<<< HEAD
         <Loader>Loading content...</Loader>
+=======
+        <Loader>Loading content</Loader>
+>>>>>>> ADd linting for alphabetical ordering
       </ThemeProvider>,
     );
 

--- a/packages/strapi-design-system/src/Loader/__tests__/Loader.spec.js
+++ b/packages/strapi-design-system/src/Loader/__tests__/Loader.spec.js
@@ -8,11 +8,7 @@ describe('Loader', () => {
   it('snapshots the component', () => {
     const { container } = render(
       <ThemeProvider theme={lightTheme}>
-<<<<<<< HEAD
-        <Loader>Loading content...</Loader>
-=======
         <Loader>Loading content</Loader>
->>>>>>> ADd linting for alphabetical ordering
       </ThemeProvider>,
     );
 
@@ -41,7 +37,7 @@ describe('Loader', () => {
         <div
           class="c0"
         >
-          Loading content...
+          Loading content
         </div>
         <img
           aria-hidden="true"

--- a/packages/strapi-design-system/src/ProgressBar/ProgressBar.js
+++ b/packages/strapi-design-system/src/ProgressBar/ProgressBar.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { VisuallyHidden } from '../VisuallyHidden';
 
 const ProgressBarSmall = styled.div`
   background: ${({ theme }) => theme.colors.neutral600};

--- a/packages/strapi-design-system/src/ProgressBar/ProgressBar.js
+++ b/packages/strapi-design-system/src/ProgressBar/ProgressBar.js
@@ -36,18 +36,10 @@ export const ProgressBar = ({ min, max, value, children, size, ...props }) => {
   };
 
   if (size === 'M') {
-    return (
-      <ProgressBarMedium {...sharedProps} value={value} {...props}>
-        <VisuallyHidden>{children}</VisuallyHidden>
-      </ProgressBarMedium>
-    );
+    return <ProgressBarMedium {...sharedProps} value={value} aria-label={children} {...props} />;
   }
 
-  return (
-    <ProgressBarSmall {...sharedProps} value={value} {...props}>
-      <VisuallyHidden>{children}</VisuallyHidden>
-    </ProgressBarSmall>
-  );
+  return <ProgressBarSmall {...sharedProps} value={value} aria-label={children} {...props} />;
 };
 
 ProgressBar.defaultProps = {

--- a/packages/strapi-design-system/src/ProgressBar/ProgressBar.js
+++ b/packages/strapi-design-system/src/ProgressBar/ProgressBar.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { VisuallyHidden } from '../VisuallyHidden';
+
+const ProgressBarSmall = styled.div`
+  background: ${({ theme }) => theme.colors.neutral600};
+  border-radius: ${({ theme }) => theme.borderRadius};
+  position: relative;
+
+  width: 78px;
+  height: ${({ theme }) => theme.spaces[1]};
+
+  &:before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    border-radius: ${({ theme }) => theme.borderRadius};
+    width: ${({ value }) => `${value}%`};
+    background: ${({ theme }) => theme.colors.neutral150};
+  }
+`;
+
+const ProgressBarMedium = styled(ProgressBarSmall)`
+  width: 102px;
+  height: ${({ theme }) => theme.spaces[2]};
+`;
+
+export const ProgressBar = ({ min, max, value, children, size, ...props }) => {
+  const sharedProps = {
+    role: 'progressbar',
+    'aria-valuenow': value,
+    'aria-valuemin': min,
+    'aria-valuemax': max,
+  };
+
+  if (size === 'M') {
+    return (
+      <ProgressBarMedium {...sharedProps} value={value} {...props}>
+        <VisuallyHidden>{children}</VisuallyHidden>
+      </ProgressBarMedium>
+    );
+  }
+
+  return (
+    <ProgressBarSmall {...sharedProps} value={value} {...props}>
+      <VisuallyHidden>{children}</VisuallyHidden>
+    </ProgressBarSmall>
+  );
+};
+
+ProgressBar.defaultProps = {
+  min: 0,
+  max: 100,
+  value: 0,
+  size: 'M',
+};
+
+ProgressBar.propTypes = {
+  min: PropTypes.number,
+  max: PropTypes.number,
+  value: PropTypes.number,
+  children: PropTypes.string.isRequired,
+  size: PropTypes.oneOf(['S', 'M']),
+};

--- a/packages/strapi-design-system/src/ProgressBar/ProgressBar.js
+++ b/packages/strapi-design-system/src/ProgressBar/ProgressBar.js
@@ -49,9 +49,9 @@ ProgressBar.defaultProps = {
 };
 
 ProgressBar.propTypes = {
-  min: PropTypes.number,
-  max: PropTypes.number,
-  value: PropTypes.number,
   children: PropTypes.string.isRequired,
+  max: PropTypes.number,
+  min: PropTypes.number,
   size: PropTypes.oneOf(['S', 'M']),
+  value: PropTypes.number,
 };

--- a/packages/strapi-design-system/src/ProgressBar/ProgressBar.stories.mdx
+++ b/packages/strapi-design-system/src/ProgressBar/ProgressBar.stories.mdx
@@ -1,0 +1,43 @@
+<!--- ProgressBar.stories.mdx --->
+
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { withDesign } from 'storybook-addon-designs';
+import { ProgressBar } from './ProgressBar';
+
+<Meta
+  title="ProgressBar"
+  component={ProgressBar}
+  decorators={[withDesign]}
+  parameters={{
+    design: {
+      type: 'figma',
+      url: 'TODO: Fill the according figma file',
+    },
+  }}
+/>
+
+# ProgressBar
+
+This is the doc of the `ProgressBar` component
+
+## ProgressBar M
+
+Default "M" progressbar
+
+<Canvas>
+  <Story name="M">
+    <ProgressBar value={33}>100/200 plugins loaded</ProgressBar>
+  </Story>
+</Canvas>
+
+## ProgressBar S
+
+The "S" progressbar
+
+<Canvas>
+  <Story name="S">
+    <ProgressBar value={100} size="S">
+      100/200 plugins loaded
+    </ProgressBar>
+  </Story>
+</Canvas>

--- a/packages/strapi-design-system/src/ProgressBar/ProgressBar.stories.mdx
+++ b/packages/strapi-design-system/src/ProgressBar/ProgressBar.stories.mdx
@@ -26,7 +26,7 @@ Default "M" progressbar
 
 <Canvas>
   <Story name="M">
-    <ProgressBar value={33}>100/200 plugins loaded</ProgressBar>
+    <ProgressBar value={33}>33/100 plugins loaded</ProgressBar>
   </Story>
 </Canvas>
 

--- a/packages/strapi-design-system/src/ProgressBar/__tests__/ProgressBar.e2e.js
+++ b/packages/strapi-design-system/src/ProgressBar/__tests__/ProgressBar.e2e.js
@@ -3,7 +3,7 @@ import { injectAxe, checkA11y } from 'axe-playwright';
 describe('ProgressBar', () => {
   beforeEach(async () => {
     // This is the URL of the Storybook Iframe
-    await page.goto('http://localhost:6006/iframe.html?id=progressbar--base&viewMode=story');
+    await page.goto('http://localhost:6006/iframe.html?id=progressbar--m&viewMode=story');
     await injectAxe(page);
   });
 

--- a/packages/strapi-design-system/src/ProgressBar/__tests__/ProgressBar.e2e.js
+++ b/packages/strapi-design-system/src/ProgressBar/__tests__/ProgressBar.e2e.js
@@ -1,0 +1,13 @@
+import { injectAxe, checkA11y } from 'axe-playwright';
+
+describe('ProgressBar', () => {
+  beforeEach(async () => {
+    // This is the URL of the Storybook Iframe
+    await page.goto('http://localhost:6006/iframe.html?id=progressbar--base&viewMode=story');
+    await injectAxe(page);
+  });
+
+  it('triggers axe on the document', async () => {
+    await checkA11y(page);
+  });
+});

--- a/packages/strapi-design-system/src/ProgressBar/__tests__/ProgressBar.spec.js
+++ b/packages/strapi-design-system/src/ProgressBar/__tests__/ProgressBar.spec.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { ProgressBar } from '../ProgressBar';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+
+describe('ProgressBar', () => {
+  it('snapshots the component', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <ProgressBar />
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(``);
+  });
+});

--- a/packages/strapi-design-system/src/ProgressBar/__tests__/ProgressBar.spec.js
+++ b/packages/strapi-design-system/src/ProgressBar/__tests__/ProgressBar.spec.js
@@ -5,13 +5,89 @@ import { ThemeProvider } from '../../ThemeProvider';
 import { lightTheme } from '../../themes';
 
 describe('ProgressBar', () => {
-  it('snapshots the component', () => {
+  it('snapshots the component with a M size', () => {
     const { container } = render(
       <ThemeProvider theme={lightTheme}>
-        <ProgressBar />
+        <ProgressBar value={33}>33% of the plugins loaded</ProgressBar>
       </ThemeProvider>,
     );
 
-    expect(container.firstChild).toMatchInlineSnapshot(``);
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c0 {
+        background: #666687;
+        border-radius: 4px;
+        position: relative;
+        width: 78px;
+        height: 4px;
+      }
+
+      .c0:before {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        border-radius: 4px;
+        width: 33%;
+        background: #eaeaef;
+      }
+
+      .c1 {
+        width: 102px;
+        height: 8px;
+      }
+
+      <div
+        aria-label="33% of the plugins loaded"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="33"
+        class="c0 c1"
+        role="progressbar"
+        value="33"
+      />
+    `);
+  });
+
+  it('snapshots the component with a S size', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <ProgressBar value={33}>33% of the plugins loaded</ProgressBar>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c0 {
+        background: #666687;
+        border-radius: 4px;
+        position: relative;
+        width: 78px;
+        height: 4px;
+      }
+
+      .c0:before {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        border-radius: 4px;
+        width: 33%;
+        background: #eaeaef;
+      }
+
+      .c1 {
+        width: 102px;
+        height: 8px;
+      }
+
+      <div
+        aria-label="33% of the plugins loaded"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="33"
+        class="c0 c1"
+        role="progressbar"
+        value="33"
+      />
+    `);
   });
 });

--- a/packages/strapi-design-system/src/ProgressBar/index.js
+++ b/packages/strapi-design-system/src/ProgressBar/index.js
@@ -1,0 +1,1 @@
+export * from './ProgressBar';

--- a/packages/strapi-design-system/src/Radio/Radio.js
+++ b/packages/strapi-design-system/src/Radio/Radio.js
@@ -20,6 +20,6 @@ export const Radio = ({ children, ...props }) => {
 };
 
 Radio.propTypes = {
-  value: PropTypes.any.isRequired,
   children: PropTypes.string.isRequired,
+  value: PropTypes.any.isRequired,
 };


### PR DESCRIPTION
Add a Progress bar indicator

Example on: https://design-system-git-add-progressbar-strapijs.vercel.app/?path=/story/progressbar--m

## API

```jsx
<ProgressBar value={100} size="S">
   100/200 plugins loaded
</ProgressBar>
```

## Voiceover

![Screen reader usage of the progress bar on Safari](https://user-images.githubusercontent.com/3874873/116862986-e44d0980-ac05-11eb-90d8-16737738e641.gif)
