### PR TITLE
Add AssetTag component

### DIFF
--- a/packages/strapi-design-system/src/AssetTag/AssetTag.js
+++ b/packages/strapi-design-system/src/AssetTag/AssetTag.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box } from '../Box';
+import { TableLabel } from '../Text';
+import styled from 'styled-components';
+
+const AssetTagWrapper = styled(Box)`
+  display: inline-block;
+`;
+
+export const AssetTag = (props) => {
+  return (
+    <AssetTagWrapper padding={1} background="neutral100" hasRadius={true} color="neutral600">
+      <TableLabel {...props} />
+    </AssetTagWrapper>
+  );
+};
+
+AssetTag.displayName = AssetTag;
+
+AssetTag.propTypes = {};

--- a/packages/strapi-design-system/src/AssetTag/AssetTag.stories.mdx
+++ b/packages/strapi-design-system/src/AssetTag/AssetTag.stories.mdx
@@ -1,0 +1,42 @@
+<!--- AssetTag.stories.mdx --->
+
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { withDesign } from 'storybook-addon-designs';
+import { AssetTag } from './AssetTag';
+import { Stack } from '../Stack';
+
+<Meta
+  title="AssetTag"
+  component={AssetTag}
+  decorators={[withDesign]}
+  parameters={{
+    design: {
+      type: 'figma',
+      url: 'TODO: Fill the according figma file',
+    },
+  }}
+/>
+
+# AssetTag
+
+This is the doc of the `AssetTag` component
+
+## AssetTag
+
+Description...
+
+<Canvas>
+  <Story name="base">
+    <Stack size={2}>
+      <div>
+        <AssetTag>Doc</AssetTag>
+      </div>
+      <div>
+        <AssetTag>Video</AssetTag>
+      </div>
+      <div>
+        <AssetTag>Image</AssetTag>
+      </div>
+    </Stack>
+  </Story>
+</Canvas>

--- a/packages/strapi-design-system/src/AssetTag/__tests__/AssetTag.e2e.js
+++ b/packages/strapi-design-system/src/AssetTag/__tests__/AssetTag.e2e.js
@@ -1,0 +1,13 @@
+import { injectAxe, checkA11y } from 'axe-playwright';
+
+describe('AssetTag', () => {
+  beforeEach(async () => {
+    // This is the URL of the Storybook Iframe
+    await page.goto('http://localhost:6006/iframe.html?id=assettag--base&viewMode=story');
+    await injectAxe(page);
+  });
+
+  it('triggers axe on the document', async () => {
+    await checkA11y(page);
+  });
+});

--- a/packages/strapi-design-system/src/AssetTag/__tests__/AssetTag.spec.js
+++ b/packages/strapi-design-system/src/AssetTag/__tests__/AssetTag.spec.js
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { AssetTag } from '../AssetTag';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+
+describe('AssetTag', () => {
+  it('snapshots the component', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <AssetTag>Doc</AssetTag>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c0 {
+        background: #f6f6f9;
+        color: #666687;
+        padding: 4px;
+        border-radius: 4px;
+      }
+
+      .c2 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+      }
+
+      .c3 {
+        font-weight: 600;
+        line-height: 1.14;
+      }
+
+      .c4 {
+        font-weight: 600;
+        font-size: 0.6875rem;
+        line-height: 1.45;
+        text-transform: uppercase;
+      }
+
+      .c1 {
+        display: inline-block;
+      }
+
+      <div
+        class="c0 c1"
+      >
+        <p
+          class="c2 c3 c4"
+        >
+          Doc
+        </p>
+      </div>
+    `);
+  });
+});

--- a/packages/strapi-design-system/src/AssetTag/index.js
+++ b/packages/strapi-design-system/src/AssetTag/index.js
@@ -1,0 +1,1 @@
+export * from './AssetTag';


### PR DESCRIPTION
Add AssetTag component

I've taken the freedom to use neutral600 instead of neutral500 for the text color since the color contrast was not sufficient

## API

```jsx
 <AssetTag>Doc</AssetTag>
```

## What it looks like

<img width="130" alt="AssetTag in storybook" src="https://user-images.githubusercontent.com/3874873/117304820-765f4700-ae7e-11eb-83e9-7c032a3dd938.png">
