### PR TITLE
Add FocusTrap component

### DIFF
--- a/packages/strapi-design-system/jest.e2e.js
+++ b/packages/strapi-design-system/jest.e2e.js
@@ -6,7 +6,7 @@ module.exports = {
     'jest-playwright': {
       browsers: ['chromium', 'firefox', 'webkit'],
       launchOptions: {
-        // headless: false,
+        headless: false,
         // devtools: true,
       },
     },

--- a/packages/strapi-design-system/jest.e2e.js
+++ b/packages/strapi-design-system/jest.e2e.js
@@ -6,7 +6,7 @@ module.exports = {
     'jest-playwright': {
       browsers: ['chromium', 'firefox', 'webkit'],
       launchOptions: {
-        headless: false,
+        // headless: false,
         // devtools: true,
       },
     },

--- a/packages/strapi-design-system/src/Button/Button.js
+++ b/packages/strapi-design-system/src/Button/Button.js
@@ -54,7 +54,9 @@ export const Button = ({ variant, leftIcon, rightIcon, disabled, children, size,
           {leftIcon}
         </Box>
       )}
-      <Text small={size === 'S'}>{children}</Text>
+      <Text small={size === 'S'} as="span">
+        {children}
+      </Text>
       {rightIcon && (
         <Box aria-hidden={true} paddingLeft={2}>
           {rightIcon}

--- a/packages/strapi-design-system/src/Button/__tests__/Button.spec.js
+++ b/packages/strapi-design-system/src/Button/__tests__/Button.spec.js
@@ -99,11 +99,11 @@ describe('Button', () => {
         aria-disabled="false"
         class="c0"
       >
-        <p
+        <span
           class="c1 c2"
         >
           Hello world
-        </p>
+        </span>
       </button>
     `);
   });
@@ -221,11 +221,11 @@ describe('Button', () => {
         aria-disabled="false"
         class="c0"
       >
-        <p
+        <span
           class="c1 c2"
         >
           Submit
-        </p>
+        </span>
       </button>
     `);
   });
@@ -324,11 +324,11 @@ describe('Button', () => {
         aria-disabled="false"
         class="c0"
       >
-        <p
+        <span
           class="c1 c2"
         >
           Success
-        </p>
+        </span>
       </button>
     `);
   });
@@ -446,11 +446,11 @@ describe('Button', () => {
         aria-disabled="false"
         class="c0"
       >
-        <p
+        <span
           class="c1 c2"
         >
           Remove
-        </p>
+        </span>
       </button>
     `);
   });
@@ -549,11 +549,11 @@ describe('Button', () => {
         aria-disabled="false"
         class="c0"
       >
-        <p
+        <span
           class="c1 c2"
         >
           Button
-        </p>
+        </span>
       </button>
     `);
   });

--- a/packages/strapi-design-system/src/FocusTrap/ExampleComponent.js
+++ b/packages/strapi-design-system/src/FocusTrap/ExampleComponent.js
@@ -1,0 +1,60 @@
+/* eslint-disable react/prop-types */
+import React, { useRef, useState } from 'react';
+import { Box } from '../Box';
+import { Stack } from '../Stack';
+import { Text, H2 } from '../Text';
+import { Button } from '../Button';
+import { Row } from '../Row';
+import { CloseAlertIcon } from '@strapi/icons';
+import { FocusTrap } from './FocusTrap';
+
+const TrappedComponent = ({ onClose }) => {
+  return (
+    <FocusTrap onEscape={onClose}>
+      <Box background="neutral0" padding={4} hasRadius style={{ width: '600px' }}>
+        <Stack size={2}>
+          <Row justifyContent="space-between">
+            <H2>Hey folks!</H2>
+            <button style={{ border: 'none', background: 'transparent' }} onClick={onClose} aria-label="Close">
+              <CloseAlertIcon aria-hidden={true} />
+            </button>
+          </Row>
+          <Box paddingTop={2} paddingBottom={2}>
+            <Text>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+              dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+              ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+              fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+              mollit anim id est laborum.
+            </Text>
+          </Box>
+          <Row justifyContent="space-between">
+            <Button id="second">Second focusable</Button>
+            <Button id="last">Last focusable</Button>
+          </Row>
+        </Stack>
+      </Box>
+    </FocusTrap>
+  );
+};
+
+export const ExampleComponent = () => {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <Box background="neutral150" padding={10}>
+      <Stack size={2}>
+        {visible && <TrappedComponent onClose={() => setVisible(false)} />}
+        <Box background="neutral0" padding={4} hasRadius style={{ width: '600px' }}>
+          <H2>Outside the trap!</H2>
+
+          <Box paddingTop={2}>
+            <Button onClick={() => setVisible(true)} id="trigger">
+              Open the trap
+            </Button>
+          </Box>
+        </Box>
+      </Stack>
+    </Box>
+  );
+};

--- a/packages/strapi-design-system/src/FocusTrap/FocusTrap.js
+++ b/packages/strapi-design-system/src/FocusTrap/FocusTrap.js
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { getFocusableNodes } from '../helpers/getFocusableNodes';
+import { KeyboardKeys } from '../helpers/keyboardKeys';
+
+export const FocusTrap = ({ onEscape, restoreFocus, ...props }) => {
+  const trappedRef = useRef(null);
+
+  useEffect(() => {
+    if (restoreFocus) {
+      const currentFocus = document.activeElement;
+
+      return () => {
+        currentFocus.focus();
+      };
+    }
+  }, [restoreFocus]);
+
+  useEffect(() => {
+    if (!trappedRef.current) return;
+
+    const focusableChildren = getFocusableNodes(trappedRef.current);
+
+    if (focusableChildren.length > 0) {
+      const firstElement = focusableChildren.item(0);
+      const lastElement = focusableChildren.item(focusableChildren.length - 1);
+
+      // Send the focus to the first element when mounting
+      firstElement.focus();
+
+      const handleKeyDown = (e) => {
+        if (e.key === KeyboardKeys.ESCAPE) {
+          return onEscape();
+        }
+
+        if (e.key !== KeyboardKeys.TAB) return;
+
+        if (e.shiftKey) {
+          if (firstElement === document.activeElement) {
+            e.preventDefault();
+            lastElement.focus();
+          }
+        } else {
+          if (lastElement === document.activeElement) {
+            e.preventDefault();
+            firstElement.focus();
+          }
+        }
+      };
+
+      trappedRef.current?.addEventListener('keydown', handleKeyDown);
+
+      return () => {
+        trappedRef.current?.removeEventListener('keydown', handleKeyDown);
+      };
+    }
+  }, []);
+
+  return <div ref={trappedRef} {...props} />;
+};
+
+FocusTrap.defaultProps = {
+  restoreFocus: true,
+};
+
+FocusTrap.propTypes = {
+  onEscape: PropTypes.func.isRequired,
+  restoreFocus: PropTypes.bool,
+};

--- a/packages/strapi-design-system/src/FocusTrap/FocusTrap.stories.mdx
+++ b/packages/strapi-design-system/src/FocusTrap/FocusTrap.stories.mdx
@@ -1,0 +1,32 @@
+<!--- FocusTrap.stories.mdx --->
+
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { withDesign } from 'storybook-addon-designs';
+import { FocusTrap } from './FocusTrap';
+import { ExampleComponent } from './ExampleComponent';
+
+<Meta
+  title="FocusTrap"
+  component={FocusTrap}
+  decorators={[withDesign]}
+  parameters={{
+    design: {
+      type: 'figma',
+      url: 'TODO: Fill the according figma file',
+    },
+  }}
+/>
+
+# FocusTrap
+
+This is the doc of the `FocusTrap` component
+
+## FocusTrap
+
+Description...
+
+<Canvas>
+  <Story name="base">
+    <ExampleComponent />
+  </Story>
+</Canvas>

--- a/packages/strapi-design-system/src/FocusTrap/__tests__/FocusTrap.e2e.js
+++ b/packages/strapi-design-system/src/FocusTrap/__tests__/FocusTrap.e2e.js
@@ -1,0 +1,95 @@
+import { injectAxe, checkA11y } from 'axe-playwright';
+
+describe('FocusTrap', () => {
+  beforeEach(async () => {
+    // This is the URL of the Storybook Iframe
+    await page.goto('http://localhost:6006/iframe.html?id=focustrap--base&viewMode=story');
+    await injectAxe(page);
+  });
+
+  beforeEach(async () => {
+    await page.focus('#trigger');
+    await page.keyboard.press('Space');
+  });
+
+  it('triggers axe on the document', async () => {
+    await checkA11y(page);
+  });
+
+  it('focuses the first focusable element when opening the focus trap', async () => {
+    await expect(page).toHaveFocus('[aria-label="Close"]');
+  });
+
+  it('restores focus when pressing Escape', async () => {
+    await page.waitForSelector('[aria-label="Close"]');
+    await page.keyboard.press('Escape');
+
+    await expect(page).toHaveFocus('#trigger');
+  });
+
+  describe('Pressing Tab in the trap', () => {
+    it.jestPlaywrightSkip(
+      { browsers: ['webkit'] },
+      'traps the focus when pressing Tab for Firefox and Chrome',
+      async () => {
+        await page.keyboard.press('Tab');
+        await expect(page).toHaveFocus('#second');
+
+        await page.keyboard.press('Tab');
+        await expect(page).toHaveFocus('#last');
+
+        await page.keyboard.press('Tab');
+        await expect(page).toHaveFocus('[aria-label="Close"]');
+      },
+    );
+
+    it.jestPlaywrightSkip(
+      { browsers: ['firefox', 'chromium'] },
+      'traps the focus when pressing Tab for Webkit',
+      async () => {
+        await page.waitForSelector('[aria-label="Close"]');
+        await page.keyboard.press('Alt+Tab');
+        await expect(page).toHaveFocus('#second');
+
+        await page.keyboard.press('Alt+Tab');
+        await expect(page).toHaveFocus('#last');
+
+        await page.keyboard.press('Alt+Tab');
+        await expect(page).toHaveFocus('[aria-label="Close"]');
+      },
+    );
+  });
+
+  describe('Pressing Shift+Tab in the trap', () => {
+    it.jestPlaywrightSkip(
+      { browsers: ['webkit'] },
+      'traps the focus when pressing Tab for Firefox and Chrome',
+      async () => {
+        await page.keyboard.press('Shift+Tab');
+        await expect(page).toHaveFocus('#last');
+
+        await page.keyboard.press('Shift+Tab');
+        await expect(page).toHaveFocus('#second');
+
+        await page.keyboard.press('Shift+Tab');
+        await expect(page).toHaveFocus('[aria-label="Close"]');
+      },
+    );
+
+    it.jestPlaywrightSkip(
+      { browsers: ['firefox', 'chromium'] },
+      'traps the focus when pressing Tab for Webkit',
+      async () => {
+        await page.waitForSelector('[aria-label="Close"]');
+        await page.keyboard.press('Alt+Shift+Tab');
+        await expect(page).toHaveFocus('#last');
+
+        await page.keyboard.press('Alt+Shift+Tab');
+        await expect(page).toHaveFocus('#second');
+
+        await page.keyboard.press('Alt+Shift+Tab');
+        await expect(page).toHaveFocus('[aria-label="Close"]');
+      },
+    );
+  });
+});

--- a/packages/strapi-design-system/src/FocusTrap/__tests__/FocusTrap.spec.js
+++ b/packages/strapi-design-system/src/FocusTrap/__tests__/FocusTrap.spec.js
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { FocusTrap } from '../FocusTrap';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+
+describe('FocusTrap', () => {
+  it('snapshots the component', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <FocusTrap onEscape={() => undefined}>
+          <div>Focus scoped</div>
+        </FocusTrap>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <div>
+        <div>
+          Focus scoped
+        </div>
+      </div>
+    `);
+  });
+});

--- a/packages/strapi-design-system/src/FocusTrap/index.js
+++ b/packages/strapi-design-system/src/FocusTrap/index.js
@@ -1,0 +1,1 @@
+export * from './FocusTrap';

--- a/packages/strapi-design-system/src/helpers/getFocusableNodes.js
+++ b/packages/strapi-design-system/src/helpers/getFocusableNodes.js
@@ -1,0 +1,4 @@
+export const getFocusableNodes = (node) =>
+  node.querySelectorAll(
+    'a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])',
+  );

--- a/packages/strapi-design-system/src/helpers/keyboardKeys.js
+++ b/packages/strapi-design-system/src/helpers/keyboardKeys.js
@@ -1,0 +1,13 @@
+export const KeyboardKeys = {
+  DOWN: 'ArrowDown',
+  UP: 'ArrowUp',
+  ARROW_RIGHT: 'ArrowRight',
+  ARROW_LEFT: 'ArrowLeft',
+  ESCAPE: 'Escape',
+  ENTER: 'Enter',
+  SPACE: ' ',
+  TAB: 'Tab',
+  END: 'End',
+  HOME: 'Home',
+  DELETE: 'Delete',
+};


### PR DESCRIPTION
The focus trap component aims to prevent focus from going outside the box. Practical for modals / dialogs. It also bring back the focus to the caller when unmounting

## API

```jsx
<FocusTrap>
  <button>I m done buddie</button>
</FocusTrap>
```

## Example

![A storybook example of the FocusTrap component](https://user-images.githubusercontent.com/3874873/117412267-df919980-af14-11eb-9b04-b595e9c9e89d.gif)

