### PR TITLE
Add Alert component

### DIFF
--- a/packages/strapi-design-system/src/Alert/Alert.js
+++ b/packages/strapi-design-system/src/Alert/Alert.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { AlertInfoIcon, AlertSucessIcon, AlertWarningIcon, CloseAlertIcon } from '@strapi/icons';
+import { Box } from '../Box';
+import { Text } from '../Text';
+import { Row } from '../Row';
+import { handleBackgroundColor, handleBorderColor, handleIconColor } from './utils';
+
+const AlertBody = styled(Box)`
+  flex: 1;
+  flex-wrap: wrap;
+  display: flex;
+  flex-direction: row;
+`;
+
+const AlertWrapper = styled(Box)`
+  border: 1px solid ${handleBorderColor};
+  background: ${handleBackgroundColor};
+  // TODO: fix this one when it's part of the theme
+  box-shadow: 0px 2px 15px rgba(33, 33, 52, 0.1);
+`;
+
+const CloseButton = styled.button`
+  border: none;
+  background: transparent;
+  font-size: ${12 / 16}rem;
+  svg path {
+    fill: ${({ theme }) => theme.colors.neutral700};
+  }
+  margin-top: ${({ theme }) => theme.spaces[1]};
+`;
+
+const AlertIconWrapper = styled(Box)`
+  font-size: ${20 / 16}rem;
+  svg path {
+    fill: ${handleIconColor};
+  }
+`;
+
+const AlertIcon = ({ variant, ...props }) => {
+  if (variant === 'success') {
+    return <AlertSucessIcon {...props} />;
+  }
+
+  if (variant === 'danger') {
+    return <AlertWarningIcon {...props} />;
+  }
+
+  return <AlertInfoIcon {...props} />;
+};
+
+export const Alert = ({ title, children, variant, onClose, closeLabel }) => {
+  return (
+    <AlertWrapper hasRadius paddingLeft={5} paddingRight={6} paddingTop={5} variant={variant}>
+      <Row alignItems="flex-start">
+        <AlertIconWrapper paddingRight={3} variant={variant}>
+          <AlertIcon variant={variant} aria-hidden={true} />
+        </AlertIconWrapper>
+        <AlertBody>
+          <Box paddingBottom={2} paddingRight={1}>
+            <Text highlighted={true} textColor="neutral800">
+              {title}
+            </Text>
+          </Box>
+
+          <Box paddingBottom={5}>
+            <Text textColor="neutral800">{children}</Text>
+          </Box>
+        </AlertBody>
+        <CloseButton onClick={onClose} aria-label={closeLabel}>
+          <CloseAlertIcon aria-hidden={true} />
+        </CloseButton>
+      </Row>
+    </AlertWrapper>
+  );
+};
+
+Alert.defaultProps = {
+  variant: 'default',
+};
+
+Alert.propTypes = {
+  children: PropTypes.string.isRequired,
+  closeLabel: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  variant: PropTypes.oneOf(['danger', 'success', 'default']),
+};
+
+AlertIcon.propTypes = {
+  variant: Alert.propTypes.variant,
+};

--- a/packages/strapi-design-system/src/Alert/Alert.js
+++ b/packages/strapi-design-system/src/Alert/Alert.js
@@ -18,8 +18,7 @@ const AlertBody = styled(Box)`
 const AlertWrapper = styled(Box)`
   border: 1px solid ${handleBorderColor};
   background: ${handleBackgroundColor};
-  // TODO: fix this one when it's part of the theme
-  box-shadow: 0px 2px 15px rgba(33, 33, 52, 0.1);
+  box-shadow: ${({ theme }) => theme.shadows.filterShadow};
 `;
 
 const CloseButton = styled.button`
@@ -51,6 +50,20 @@ const AlertIcon = ({ variant, ...props }) => {
   return <AlertInfoIcon {...props} />;
 };
 
+const ActionBox = styled(Box)`
+  & a {
+    line-height: ${12 / 16}rem;
+  }
+
+  & a > span {
+    color: ${handleIconColor};
+
+    svg path {
+      fill: ${handleIconColor};
+    }
+  }
+`;
+
 export const Alert = ({ title, children, variant, onClose, closeLabel, titleAs, action, ...props }) => {
   return (
     <AlertWrapper hasRadius paddingLeft={5} paddingRight={6} paddingTop={5} variant={variant} {...props}>
@@ -69,7 +82,11 @@ export const Alert = ({ title, children, variant, onClose, closeLabel, titleAs, 
             <Text textColor="neutral800">{children}</Text>
           </Box>
 
-          {action && <Box paddingBottom={5}>{action}</Box>}
+          {action && (
+            <ActionBox paddingBottom={5} variant={variant}>
+              {action}
+            </ActionBox>
+          )}
         </AlertBody>
 
         <CloseButton onClick={onClose} aria-label={closeLabel}>

--- a/packages/strapi-design-system/src/Alert/Alert.js
+++ b/packages/strapi-design-system/src/Alert/Alert.js
@@ -5,6 +5,7 @@ import { AlertInfoIcon, AlertSucessIcon, AlertWarningIcon, CloseAlertIcon } from
 import { Box } from '../Box';
 import { Text } from '../Text';
 import { Row } from '../Row';
+import { Link } from '../Link';
 import { handleBackgroundColor, handleBorderColor, handleIconColor } from './utils';
 
 const AlertBody = styled(Box)`
@@ -50,7 +51,7 @@ const AlertIcon = ({ variant, ...props }) => {
   return <AlertInfoIcon {...props} />;
 };
 
-export const Alert = ({ title, children, variant, onClose, closeLabel, titleAs, ...props }) => {
+export const Alert = ({ title, children, variant, onClose, closeLabel, titleAs, action, ...props }) => {
   return (
     <AlertWrapper hasRadius paddingLeft={5} paddingRight={6} paddingTop={5} variant={variant} {...props}>
       <Row alignItems="flex-start">
@@ -64,10 +65,13 @@ export const Alert = ({ title, children, variant, onClose, closeLabel, titleAs, 
             </Text>
           </Box>
 
-          <Box paddingBottom={5}>
+          <Box paddingBottom={action ? 2 : 5} paddingRight={2}>
             <Text textColor="neutral800">{children}</Text>
           </Box>
+
+          {action && <Box paddingBottom={5}>{action}</Box>}
         </AlertBody>
+
         <CloseButton onClick={onClose} aria-label={closeLabel}>
           <CloseAlertIcon aria-hidden={true} />
         </CloseButton>
@@ -77,11 +81,13 @@ export const Alert = ({ title, children, variant, onClose, closeLabel, titleAs, 
 };
 
 Alert.defaultProps = {
+  action: undefined,
   variant: 'default',
   titleAs: 'p',
 };
 
 Alert.propTypes = {
+  action: PropTypes.element,
   children: PropTypes.string.isRequired,
   closeLabel: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,

--- a/packages/strapi-design-system/src/Alert/Alert.js
+++ b/packages/strapi-design-system/src/Alert/Alert.js
@@ -50,9 +50,17 @@ const AlertIcon = ({ variant, ...props }) => {
   return <AlertInfoIcon {...props} />;
 };
 
-export const Alert = ({ title, children, variant, onClose, closeLabel, titleAs }) => {
+export const Alert = ({ title, children, variant, onClose, closeLabel, titleAs, ...props }) => {
   return (
-    <AlertWrapper hasRadius paddingLeft={5} paddingRight={6} paddingTop={5} variant={variant}>
+    <AlertWrapper
+      hasRadius
+      paddingLeft={5}
+      paddingRight={6}
+      paddingTop={5}
+      variant={variant}
+      role={variant === 'danger' ? 'alert' : 'status'}
+      {...props}
+    >
       <Row alignItems="flex-start">
         <AlertIconWrapper paddingRight={3} variant={variant}>
           <AlertIcon variant={variant} aria-hidden={true} />

--- a/packages/strapi-design-system/src/Alert/Alert.js
+++ b/packages/strapi-design-system/src/Alert/Alert.js
@@ -52,20 +52,12 @@ const AlertIcon = ({ variant, ...props }) => {
 
 export const Alert = ({ title, children, variant, onClose, closeLabel, titleAs, ...props }) => {
   return (
-    <AlertWrapper
-      hasRadius
-      paddingLeft={5}
-      paddingRight={6}
-      paddingTop={5}
-      variant={variant}
-      role={variant === 'danger' ? 'alert' : 'status'}
-      {...props}
-    >
+    <AlertWrapper hasRadius paddingLeft={5} paddingRight={6} paddingTop={5} variant={variant} {...props}>
       <Row alignItems="flex-start">
         <AlertIconWrapper paddingRight={3} variant={variant}>
           <AlertIcon variant={variant} aria-hidden={true} />
         </AlertIconWrapper>
-        <AlertBody>
+        <AlertBody role={variant === 'danger' ? 'alert' : 'status'}>
           <Box paddingBottom={2} paddingRight={1}>
             <Text highlighted={true} textColor="neutral800" as={titleAs}>
               {title}

--- a/packages/strapi-design-system/src/Alert/Alert.js
+++ b/packages/strapi-design-system/src/Alert/Alert.js
@@ -50,7 +50,7 @@ const AlertIcon = ({ variant, ...props }) => {
   return <AlertInfoIcon {...props} />;
 };
 
-export const Alert = ({ title, children, variant, onClose, closeLabel }) => {
+export const Alert = ({ title, children, variant, onClose, closeLabel, titleAs }) => {
   return (
     <AlertWrapper hasRadius paddingLeft={5} paddingRight={6} paddingTop={5} variant={variant}>
       <Row alignItems="flex-start">
@@ -59,7 +59,7 @@ export const Alert = ({ title, children, variant, onClose, closeLabel }) => {
         </AlertIconWrapper>
         <AlertBody>
           <Box paddingBottom={2} paddingRight={1}>
-            <Text highlighted={true} textColor="neutral800">
+            <Text highlighted={true} textColor="neutral800" as={titleAs}>
               {title}
             </Text>
           </Box>
@@ -78,6 +78,7 @@ export const Alert = ({ title, children, variant, onClose, closeLabel }) => {
 
 Alert.defaultProps = {
   variant: 'default',
+  titleAs: 'p',
 };
 
 Alert.propTypes = {
@@ -85,6 +86,7 @@ Alert.propTypes = {
   closeLabel: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
+  titleAs: PropTypes.string,
   variant: PropTypes.oneOf(['danger', 'success', 'default']),
 };
 

--- a/packages/strapi-design-system/src/Alert/Alert.stories.mdx
+++ b/packages/strapi-design-system/src/Alert/Alert.stories.mdx
@@ -1,0 +1,57 @@
+<!--- Alert.stories.mdx --->
+
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { withDesign } from 'storybook-addon-designs';
+import { Alert } from './Alert';
+import { Box } from '../Box';
+import { Stack } from '../Stack';
+
+<Meta
+  title="Alert"
+  component={Alert}
+  decorators={[withDesign]}
+  parameters={{
+    design: {
+      type: 'figma',
+      url: 'TODO: Fill the according figma file',
+    },
+  }}
+/>
+
+# Alert
+
+This is the doc of the `Alert` component
+
+## Alert
+
+Description...
+
+<Canvas>
+  <Story name="base">
+    <Box padding={10} style={{ width: 700 }}>
+      <Stack size={4}>
+        <Alert title="Default variant" onClose={() => {}} closeLabel="Close notification">
+          Alert with title and longer description, lorem ipsum dolor sit amet constrectum adipisicng lorem ipsum dolor
+          sit amet consrectumis adipisingus.
+        </Alert>
+        <Alert title="Success variant" variant="success" onClose={() => {}} closeLabel="Close notification">
+          Alert with title and longer description, lorem ipsum dolor sit amet constrectum adipisicng lorem ipsum dolor
+          sit amet consrectumis adipisingus.
+        </Alert>
+        <Alert title="Danger variant" variant="danger" onClose={() => {}} closeLabel="Close notification">
+          Alert with title and longer description, lorem ipsum dolor sit amet constrectum adipisicng lorem ipsum dolor
+          sit amet consrectumis adipisingus.
+        </Alert>
+        <Alert title="Default variant" onClose={() => {}} closeLabel="Close notification">
+          Alert with title and longer description
+        </Alert>
+        <Alert title="Success variant" variant="success" onClose={() => {}} closeLabel="Close notification">
+          Alert with title and longer description
+        </Alert>
+        <Alert title="Danger variant" variant="danger" onClose={() => {}} closeLabel="Close notification">
+          Alert with title and longer description
+        </Alert>
+      </Stack>
+    </Box>
+  </Story>
+</Canvas>

--- a/packages/strapi-design-system/src/Alert/Alert.stories.mdx
+++ b/packages/strapi-design-system/src/Alert/Alert.stories.mdx
@@ -6,6 +6,7 @@ import { withDesign } from 'storybook-addon-designs';
 import { Alert } from './Alert';
 import { Box } from '../Box';
 import { Stack } from '../Stack';
+import { Link } from '../Link';
 
 <Meta
   title="Alert"
@@ -31,25 +32,59 @@ Description...
   <Story name="base">
     <Box padding={10} style={{ width: 700 }}>
       <Stack size={4}>
-        <Alert title="Default variant" onClose={() => {}} closeLabel="Close notification">
+        <Alert
+          title="Default variant"
+          onClose={() => {}}
+          closeLabel="Close notification"
+          action={<Link href="/somewhere">See more</Link>}
+        >
           Alert with title and longer description, lorem ipsum dolor sit amet constrectum adipisicng lorem ipsum dolor
           sit amet consrectumis adipisingus.
         </Alert>
-        <Alert title="Success variant" variant="success" onClose={() => {}} closeLabel="Close notification">
+        <Alert
+          title="Success variant"
+          variant="success"
+          onClose={() => {}}
+          closeLabel="Close notification"
+          action={<Link href="/somewhere">See more</Link>}
+        >
           Alert with title and longer description, lorem ipsum dolor sit amet constrectum adipisicng lorem ipsum dolor
           sit amet consrectumis adipisingus.
         </Alert>
-        <Alert title="Danger variant" variant="danger" onClose={() => {}} closeLabel="Close notification">
+        <Alert
+          title="Danger variant"
+          variant="danger"
+          onClose={() => {}}
+          closeLabel="Close notification"
+          action={<Link href="/somewhere">See more</Link>}
+        >
           Alert with title and longer description, lorem ipsum dolor sit amet constrectum adipisicng lorem ipsum dolor
           sit amet consrectumis adipisingus.
         </Alert>
-        <Alert title="Default variant" onClose={() => {}} closeLabel="Close notification">
+        <Alert
+          title="Default variant"
+          onClose={() => {}}
+          closeLabel="Close notification"
+          action={<Link href="/somewhere">See more</Link>}
+        >
           Alert with title and longer description
         </Alert>
-        <Alert title="Success variant" variant="success" onClose={() => {}} closeLabel="Close notification">
+        <Alert
+          title="Success variant"
+          variant="success"
+          onClose={() => {}}
+          closeLabel="Close notification"
+          action={<Link href="/somewhere">See more</Link>}
+        >
           Alert with title and longer description
         </Alert>
-        <Alert title="Danger variant" variant="danger" onClose={() => {}} closeLabel="Close notification">
+        <Alert
+          title="Danger variant"
+          variant="danger"
+          onClose={() => {}}
+          closeLabel="Close notification"
+          action={<Link href="/somewhere">See more</Link>}
+        >
           Alert with title and longer description
         </Alert>
       </Stack>

--- a/packages/strapi-design-system/src/Alert/Alert.stories.mdx
+++ b/packages/strapi-design-system/src/Alert/Alert.stories.mdx
@@ -1,5 +1,6 @@
 <!--- Alert.stories.mdx --->
 
+import { useState } from 'react';
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import { withDesign } from 'storybook-addon-designs';
 import { Alert } from './Alert';
@@ -53,5 +54,30 @@ Description...
         </Alert>
       </Stack>
     </Box>
+  </Story>
+</Canvas>
+
+## Alert
+
+Description...
+
+<Canvas>
+  <Story name="live region">
+    {() => {
+      const [visible, setVisible] = useState(false);
+      return (
+        <Box padding={10} style={{ width: 700 }}>
+          <Stack size={4}>
+            <button onClick={() => setVisible((s) => !s)}>Open alert</button>
+            {visible && (
+              <Alert title="Default variant" onClose={() => {}} closeLabel="Close notification" variant="danger">
+                Alert with title and longer description, lorem ipsum dolor sit amet constrectum adipisicng lorem ipsum
+                dolor sit amet consrectumis adipisingus.
+              </Alert>
+            )}
+          </Stack>
+        </Box>
+      );
+    }}
   </Story>
 </Canvas>

--- a/packages/strapi-design-system/src/Alert/__tests__/Alert.e2e.js
+++ b/packages/strapi-design-system/src/Alert/__tests__/Alert.e2e.js
@@ -1,0 +1,13 @@
+import { injectAxe, checkA11y } from 'axe-playwright';
+
+describe('Alert', () => {
+  beforeEach(async () => {
+    // This is the URL of the Storybook Iframe
+    await page.goto('http://localhost:6006/iframe.html?id=alert--base&viewMode=story');
+    await injectAxe(page);
+  });
+
+  it('triggers axe on the document', async () => {
+    await checkA11y(page);
+  });
+});

--- a/packages/strapi-design-system/src/Alert/__tests__/Alert.spec.js
+++ b/packages/strapi-design-system/src/Alert/__tests__/Alert.spec.js
@@ -10,6 +10,7 @@ jest.mock('@strapi/icons', () => ({
   AlertSucessIcon: () => <span>AlertSucessIcon</span>,
   AlertWarningIcon: () => <span>AlertWarningIcon</span>,
   CloseAlertIcon: () => <span>CloseAlertIcon</span>,
+  ExternalLink: () => <span>ExternalLink</span>,
 }));
 
 describe('Alert', () => {
@@ -41,6 +42,7 @@ describe('Alert', () => {
       }
 
       .c8 {
+        padding-right: 8px;
         padding-bottom: 20px;
       }
 
@@ -91,7 +93,7 @@ describe('Alert', () => {
       .c1 {
         border: 1px solid #f5c0b8;
         background: #fcecea;
-        box-shadow: 0px 2px 15px rgba(33,33,52,0.1);
+        box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
       }
 
       .c10 {
@@ -110,7 +112,7 @@ describe('Alert', () => {
       }
 
       .c4 svg path {
-        fill: #dd2b23;
+        fill: #b72b1a;
       }
 
       <div
@@ -190,6 +192,7 @@ describe('Alert', () => {
       }
 
       .c8 {
+        padding-right: 8px;
         padding-bottom: 20px;
       }
 
@@ -240,7 +243,7 @@ describe('Alert', () => {
       .c1 {
         border: 1px solid #c6f0c2;
         background: #eafbe7;
-        box-shadow: 0px 2px 15px rgba(33,33,52,0.1);
+        box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
       }
 
       .c10 {
@@ -259,7 +262,7 @@ describe('Alert', () => {
       }
 
       .c4 svg path {
-        fill: #338648;
+        fill: #2f6846;
       }
 
       <div
@@ -339,6 +342,7 @@ describe('Alert', () => {
       }
 
       .c8 {
+        padding-right: 8px;
         padding-bottom: 20px;
       }
 
@@ -389,7 +393,7 @@ describe('Alert', () => {
       .c1 {
         border: 1px solid #d9d8ff;
         background: #f0f0ff;
-        box-shadow: 0px 2px 15px rgba(33,33,52,0.1);
+        box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
       }
 
       .c10 {
@@ -408,7 +412,7 @@ describe('Alert', () => {
       }
 
       .c4 svg path {
-        fill: #4945ff;
+        fill: #271fe0;
       }
 
       <div

--- a/packages/strapi-design-system/src/Alert/__tests__/Alert.spec.js
+++ b/packages/strapi-design-system/src/Alert/__tests__/Alert.spec.js
@@ -115,6 +115,7 @@ describe('Alert', () => {
 
       <div
         class="c0 c1"
+        role="alert"
       >
         <div
           class="c2"
@@ -263,6 +264,7 @@ describe('Alert', () => {
 
       <div
         class="c0 c1"
+        role="status"
       >
         <div
           class="c2"
@@ -411,6 +413,7 @@ describe('Alert', () => {
 
       <div
         class="c0 c1"
+        role="status"
       >
         <div
           class="c2"

--- a/packages/strapi-design-system/src/Alert/__tests__/Alert.spec.js
+++ b/packages/strapi-design-system/src/Alert/__tests__/Alert.spec.js
@@ -1,0 +1,459 @@
+/* eslint-disable react/display-name */
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Alert } from '../Alert';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+
+jest.mock('@strapi/icons', () => ({
+  AlertInfoIcon: () => <span>AlertInfoIcon</span>,
+  AlertSucessIcon: () => <span>AlertSucessIcon</span>,
+  AlertWarningIcon: () => <span>AlertWarningIcon</span>,
+  CloseAlertIcon: () => <span>CloseAlertIcon</span>,
+}));
+
+describe('Alert', () => {
+  it('snapshots the component with a "danger" variant', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Alert title="Danger variant" variant="danger" onClose={() => {}} closeLabel="Close notification">
+          Alert with title and longer description, lorem ipsum dolor sit amet constrectum adipisicng lorem ipsum dolor
+          sit amet consrectumis adipisingus.
+        </Alert>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c0 {
+        padding-top: 20px;
+        padding-right: 24px;
+        padding-left: 20px;
+        border-radius: 4px;
+      }
+
+      .c3 {
+        padding-right: 12px;
+      }
+
+      .c6 {
+        padding-right: 4px;
+        padding-bottom: 8px;
+      }
+
+      .c8 {
+        padding-bottom: 20px;
+      }
+
+      .c7 {
+        font-weight: 500;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #32324d;
+      }
+
+      .c9 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #32324d;
+      }
+
+      .c2 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-align-items: flex-start;
+        -webkit-box-align: flex-start;
+        -ms-flex-align: flex-start;
+        align-items: flex-start;
+      }
+
+      .c5 {
+        -webkit-flex: 1;
+        -ms-flex: 1;
+        flex: 1;
+        -webkit-flex-wrap: wrap;
+        -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+      }
+
+      .c1 {
+        border: 1px solid #f5c0b8;
+        background: #fcecea;
+        box-shadow: 0px 2px 15px rgba(33,33,52,0.1);
+      }
+
+      .c10 {
+        border: none;
+        background: transparent;
+        font-size: 0.75rem;
+        margin-top: 4px;
+      }
+
+      .c10 svg path {
+        fill: #4a4a6a;
+      }
+
+      .c4 {
+        font-size: 1.25rem;
+      }
+
+      .c4 svg path {
+        fill: #dd2b23;
+      }
+
+      <div
+        class="c0 c1"
+      >
+        <div
+          class="c2"
+        >
+          <div
+            class="c3 c4"
+          >
+            <span>
+              AlertWarningIcon
+            </span>
+          </div>
+          <div
+            class="c5"
+          >
+            <div
+              class="c6"
+            >
+              <p
+                class="c7"
+              >
+                Danger variant
+              </p>
+            </div>
+            <div
+              class="c8"
+            >
+              <p
+                class="c9"
+              >
+                Alert with title and longer description, lorem ipsum dolor sit amet constrectum adipisicng lorem ipsum dolor sit amet consrectumis adipisingus.
+              </p>
+            </div>
+          </div>
+          <button
+            aria-label="Close notification"
+            class="c10"
+          >
+            <span>
+              CloseAlertIcon
+            </span>
+          </button>
+        </div>
+      </div>
+    `);
+  });
+
+  it('snapshots the component with a "success" variant', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Alert title="Danger variant" variant="success" onClose={() => {}} closeLabel="Close notification">
+          Alert with title and longer description, lorem ipsum dolor sit amet constrectum adipisicng lorem ipsum dolor
+          sit amet consrectumis adipisingus.
+        </Alert>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c0 {
+        padding-top: 20px;
+        padding-right: 24px;
+        padding-left: 20px;
+        border-radius: 4px;
+      }
+
+      .c3 {
+        padding-right: 12px;
+      }
+
+      .c6 {
+        padding-right: 4px;
+        padding-bottom: 8px;
+      }
+
+      .c8 {
+        padding-bottom: 20px;
+      }
+
+      .c7 {
+        font-weight: 500;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #32324d;
+      }
+
+      .c9 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #32324d;
+      }
+
+      .c2 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-align-items: flex-start;
+        -webkit-box-align: flex-start;
+        -ms-flex-align: flex-start;
+        align-items: flex-start;
+      }
+
+      .c5 {
+        -webkit-flex: 1;
+        -ms-flex: 1;
+        flex: 1;
+        -webkit-flex-wrap: wrap;
+        -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+      }
+
+      .c1 {
+        border: 1px solid #c6f0c2;
+        background: #eafbe7;
+        box-shadow: 0px 2px 15px rgba(33,33,52,0.1);
+      }
+
+      .c10 {
+        border: none;
+        background: transparent;
+        font-size: 0.75rem;
+        margin-top: 4px;
+      }
+
+      .c10 svg path {
+        fill: #4a4a6a;
+      }
+
+      .c4 {
+        font-size: 1.25rem;
+      }
+
+      .c4 svg path {
+        fill: #338648;
+      }
+
+      <div
+        class="c0 c1"
+      >
+        <div
+          class="c2"
+        >
+          <div
+            class="c3 c4"
+          >
+            <span>
+              AlertSucessIcon
+            </span>
+          </div>
+          <div
+            class="c5"
+          >
+            <div
+              class="c6"
+            >
+              <p
+                class="c7"
+              >
+                Danger variant
+              </p>
+            </div>
+            <div
+              class="c8"
+            >
+              <p
+                class="c9"
+              >
+                Alert with title and longer description, lorem ipsum dolor sit amet constrectum adipisicng lorem ipsum dolor sit amet consrectumis adipisingus.
+              </p>
+            </div>
+          </div>
+          <button
+            aria-label="Close notification"
+            class="c10"
+          >
+            <span>
+              CloseAlertIcon
+            </span>
+          </button>
+        </div>
+      </div>
+    `);
+  });
+
+  it('snapshots the component with a "default" variant', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Alert title="Danger variant" onClose={() => {}} closeLabel="Close notification">
+          Alert with title and longer description, lorem ipsum dolor sit amet constrectum adipisicng lorem ipsum dolor
+          sit amet consrectumis adipisingus.
+        </Alert>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c0 {
+        padding-top: 20px;
+        padding-right: 24px;
+        padding-left: 20px;
+        border-radius: 4px;
+      }
+
+      .c3 {
+        padding-right: 12px;
+      }
+
+      .c6 {
+        padding-right: 4px;
+        padding-bottom: 8px;
+      }
+
+      .c8 {
+        padding-bottom: 20px;
+      }
+
+      .c7 {
+        font-weight: 500;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #32324d;
+      }
+
+      .c9 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #32324d;
+      }
+
+      .c2 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-align-items: flex-start;
+        -webkit-box-align: flex-start;
+        -ms-flex-align: flex-start;
+        align-items: flex-start;
+      }
+
+      .c5 {
+        -webkit-flex: 1;
+        -ms-flex: 1;
+        flex: 1;
+        -webkit-flex-wrap: wrap;
+        -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+      }
+
+      .c1 {
+        border: 1px solid #d9d8ff;
+        background: #f0f0ff;
+        box-shadow: 0px 2px 15px rgba(33,33,52,0.1);
+      }
+
+      .c10 {
+        border: none;
+        background: transparent;
+        font-size: 0.75rem;
+        margin-top: 4px;
+      }
+
+      .c10 svg path {
+        fill: #4a4a6a;
+      }
+
+      .c4 {
+        font-size: 1.25rem;
+      }
+
+      .c4 svg path {
+        fill: #4945ff;
+      }
+
+      <div
+        class="c0 c1"
+      >
+        <div
+          class="c2"
+        >
+          <div
+            class="c3 c4"
+          >
+            <span>
+              AlertInfoIcon
+            </span>
+          </div>
+          <div
+            class="c5"
+          >
+            <div
+              class="c6"
+            >
+              <p
+                class="c7"
+              >
+                Danger variant
+              </p>
+            </div>
+            <div
+              class="c8"
+            >
+              <p
+                class="c9"
+              >
+                Alert with title and longer description, lorem ipsum dolor sit amet constrectum adipisicng lorem ipsum dolor sit amet consrectumis adipisingus.
+              </p>
+            </div>
+          </div>
+          <button
+            aria-label="Close notification"
+            class="c10"
+          >
+            <span>
+              CloseAlertIcon
+            </span>
+          </button>
+        </div>
+      </div>
+    `);
+  });
+});

--- a/packages/strapi-design-system/src/Alert/__tests__/Alert.spec.js
+++ b/packages/strapi-design-system/src/Alert/__tests__/Alert.spec.js
@@ -115,7 +115,6 @@ describe('Alert', () => {
 
       <div
         class="c0 c1"
-        role="alert"
       >
         <div
           class="c2"
@@ -129,6 +128,7 @@ describe('Alert', () => {
           </div>
           <div
             class="c5"
+            role="alert"
           >
             <div
               class="c6"
@@ -264,7 +264,6 @@ describe('Alert', () => {
 
       <div
         class="c0 c1"
-        role="status"
       >
         <div
           class="c2"
@@ -278,6 +277,7 @@ describe('Alert', () => {
           </div>
           <div
             class="c5"
+            role="status"
           >
             <div
               class="c6"
@@ -413,7 +413,6 @@ describe('Alert', () => {
 
       <div
         class="c0 c1"
-        role="status"
       >
         <div
           class="c2"
@@ -427,6 +426,7 @@ describe('Alert', () => {
           </div>
           <div
             class="c5"
+            role="status"
           >
             <div
               class="c6"

--- a/packages/strapi-design-system/src/Alert/index.js
+++ b/packages/strapi-design-system/src/Alert/index.js
@@ -1,0 +1,1 @@
+export * from './Alert';

--- a/packages/strapi-design-system/src/Alert/utils.js
+++ b/packages/strapi-design-system/src/Alert/utils.js
@@ -24,12 +24,12 @@ export const handleBorderColor = ({ theme, variant }) => {
 
 export const handleIconColor = ({ theme, variant }) => {
   if (variant === 'danger') {
-    return theme.colors.danger600;
+    return theme.colors.danger700;
   }
 
   if (variant === 'success') {
-    return theme.colors.success600;
+    return theme.colors.success700;
   }
 
-  return theme.colors.primary600;
+  return theme.colors.primary700;
 };

--- a/packages/strapi-design-system/src/Alert/utils.js
+++ b/packages/strapi-design-system/src/Alert/utils.js
@@ -1,0 +1,35 @@
+export const handleBackgroundColor = ({ theme, variant }) => {
+  if (variant === 'danger') {
+    return theme.colors.danger100;
+  }
+
+  if (variant === 'success') {
+    return theme.colors.success100;
+  }
+
+  return theme.colors.primary100;
+};
+
+export const handleBorderColor = ({ theme, variant }) => {
+  if (variant === 'danger') {
+    return theme.colors.danger200;
+  }
+
+  if (variant === 'success') {
+    return theme.colors.success200;
+  }
+
+  return theme.colors.primary200;
+};
+
+export const handleIconColor = ({ theme, variant }) => {
+  if (variant === 'danger') {
+    return theme.colors.danger600;
+  }
+
+  if (variant === 'success') {
+    return theme.colors.success600;
+  }
+
+  return theme.colors.primary600;
+};

--- a/packages/strapi-design-system/src/Link/Link.js
+++ b/packages/strapi-design-system/src/Link/Link.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { ExternalLink } from '@strapi/icons';
 import { TableLabel } from '../Text';
 import { Box } from '../Box';
 
@@ -38,9 +39,16 @@ export const Link = ({ href, to, children, disabled, leftIcon, rightIcon, ...pro
           </Box>
         )}
         {children}
-        {rightIcon && (
+
+        {rightIcon && !href && (
           <Box as="span" aria-hidden={true} paddingLeft={2}>
             {rightIcon}
+          </Box>
+        )}
+
+        {href && (
+          <Box as="span" aria-hidden={true} paddingLeft={2}>
+            <ExternalLink />
           </Box>
         )}
       </TableLabel>

--- a/packages/strapi-design-system/src/Link/Link.stories.mdx
+++ b/packages/strapi-design-system/src/Link/Link.stories.mdx
@@ -38,8 +38,8 @@ Description...
         </Link>
       </div>
       <div>
-        <Link href="https://strapi.io/" rightIcon={<NextIcon />}>
-          External disabled link
+        <Link href="https://strapi.io/" disabled>
+          External link
         </Link>
       </div>
       <div>

--- a/packages/strapi-design-system/src/Link/__tests__/Link.spec.js
+++ b/packages/strapi-design-system/src/Link/__tests__/Link.spec.js
@@ -1,8 +1,13 @@
+/* eslint-disable react/display-name */
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { Link } from '../Link';
 import { ThemeProvider } from '../../ThemeProvider';
 import { lightTheme } from '../../themes';
+
+jest.mock('@strapi/icons', () => ({
+  ExternalLink: () => <span>ExternalLink</span>,
+}));
 
 describe('Link', () => {
   it('snapshots the component with an external link', () => {
@@ -32,6 +37,10 @@ describe('Link', () => {
         text-transform: uppercase;
       }
 
+      .c4 {
+        padding-left: 8px;
+      }
+
       .c0 {
         text-transform: uppercase;
         -webkit-text-decoration: none;
@@ -56,6 +65,14 @@ describe('Link', () => {
           class="c1 c2 c3"
         >
           External link
+          <span
+            aria-hidden="true"
+            class="c4"
+          >
+            <span>
+              ExternalLink
+            </span>
+          </span>
         </span>
       </a>
     `);

--- a/packages/strapi-design-system/src/index.js
+++ b/packages/strapi-design-system/src/index.js
@@ -10,6 +10,7 @@ export * from './Field';
 export * from './FocusTrap';
 export * from './Grid';
 export * from './IconButton';
+export * from './Link';
 export * from './Loader';
 export * from './Main';
 export * from './Pagination';


### PR DESCRIPTION
Example: https://design-system-git-add-alert-strapijs.vercel.app/

NOTE: I've moved the link color to 700 because there was a constrat issue with 600


## API

```jsx
<Alert title="Success variant" variant="success" onClose={() => {}} closeLabel="Close notification">
    Alert with title and longer description
</Alert>
```

## Look

<img width="634" alt="The Alert component running in storybook" src="https://user-images.githubusercontent.com/3874873/117814209-4e982680-b264-11eb-877b-cb133e0cd517.png">

