### PR TITLE
Add breadcrumbs

### DIFF
--- a/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
@@ -5,6 +5,7 @@ import { After } from '@strapi/icons';
 import { Text } from '../Text';
 import { Box } from '../Box';
 import { Row } from '../Row';
+import { VisuallyHidden } from '../VisuallyHidden';
 
 const CrumbWrapper = styled(Row)`
   svg {
@@ -38,10 +39,16 @@ Crumb.propTypes = {
 };
 const crumbType = PropTypes.shape({ type: PropTypes.oneOf([Crumb]) });
 
-export const Breadcrumbs = ({ children }) => <ol>{children}</ol>;
+export const Breadcrumbs = ({ children, label }) => (
+  <div>
+    <VisuallyHidden>{label}</VisuallyHidden>
+    <ol aria-hidden={true}>{children}</ol>
+  </div>
+);
 
 Breadcrumbs.displayName = 'Breadcrumbs';
 
 Breadcrumbs.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(crumbType), crumbType]).isRequired,
+  label: PropTypes.string.isRequired,
 };

--- a/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Text } from '../Text';
+import { Box } from '../Box';
+import { VisuallyHidden } from '../VisuallyHidden';
+import { useId } from '../helpers/useId';
+
+const BreadCrumbItemWrapper = styled.li`
+  display: inline-flex;
+`;
+
+export const BreadCrumbItem = React.forwardRef(({ children, isLastChild, separator }, ref) => {
+  return (
+    <BreadCrumbItemWrapper ref={ref}>
+      <Text>{children}</Text>
+      {!isLastChild && (
+        <Box paddingLeft={1} paddingRight={1}>
+          {separator}
+        </Box>
+      )}
+    </BreadCrumbItemWrapper>
+  );
+});
+BreadCrumbItem.displayName = 'BreadCrumbItem';
+BreadCrumbItem.defaultProps = {
+  isLastChild: false,
+  separator: '/',
+};
+BreadCrumbItem.propTypes = {
+  children: PropTypes.string.isRequired,
+  isLastChild: PropTypes.bool,
+  separator: PropTypes.string,
+};
+
+export const Breadcrumbs = React.forwardRef(({ label, description, children, ...props }, ref) => {
+  const breadCrumbsId = useId('breadcrumbs');
+  const descriptionId = useId('description');
+  const validChildren = React.Children.toArray(children).filter((child) => React.isValidElement(child));
+  const elements = validChildren.map((child, index) =>
+    React.cloneElement(child, {
+      separator: '/',
+      spacing: 1,
+      isLastChild: validChildren.length === index + 1,
+    }),
+  );
+
+  return (
+    <nav id={breadCrumbsId} aria-describedby={descriptionId} aria-label={label} ref={ref} {...props}>
+      <VisuallyHidden id={descriptionId}>{description}</VisuallyHidden>
+      <ol>{elements}</ol>
+    </nav>
+  );
+});
+
+Breadcrumbs.displayName = 'Breadcrumbs';
+
+Breadcrumbs.defaultProps = {
+  description: undefined,
+  label: undefined,
+};
+Breadcrumbs.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)]).isRequired,
+  description: PropTypes.string,
+  label: PropTypes.string,
+};

--- a/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
@@ -1,36 +1,44 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { After } from '@strapi/icons';
 import { Text } from '../Text';
 import { Box } from '../Box';
 import { useId } from '../helpers/useId';
 
-const BreadCrumbItemWrapper = styled.li`
+const CrumbWrapper = styled.li`
   display: inline-flex;
   align-items: center;
+  svg {
+    height: 10px;
+    width: 10px;
+  }
+  svg path {
+    fill: ${({ theme }) => theme.colors.neutral300};
+  }
 `;
 
-export const BreadCrumbItem = React.forwardRef(({ children, isLastChild, separator }, ref) => {
+export const Crumb = React.forwardRef(({ children, isLastChild }, ref) => {
   return (
-    <BreadCrumbItemWrapper ref={ref}>
-      <Text>{children}</Text>
+    <CrumbWrapper ref={ref}>
+      <Text highlighted color="neutral800">
+        {children}
+      </Text>
       {!isLastChild && (
-        <Box paddingLeft={1} paddingRight={1}>
-          {separator}
+        <Box paddingLeft={3} paddingRight={3}>
+          <After />
         </Box>
       )}
-    </BreadCrumbItemWrapper>
+    </CrumbWrapper>
   );
 });
-BreadCrumbItem.displayName = 'BreadCrumbItem';
-BreadCrumbItem.defaultProps = {
+Crumb.displayName = 'Crumb';
+Crumb.defaultProps = {
   isLastChild: false,
-  separator: '/',
 };
-BreadCrumbItem.propTypes = {
+Crumb.propTypes = {
   children: PropTypes.string.isRequired,
   isLastChild: PropTypes.bool,
-  separator: PropTypes.string,
 };
 
 export const Breadcrumbs = React.forwardRef(({ children, ...props }, ref) => {
@@ -38,7 +46,6 @@ export const Breadcrumbs = React.forwardRef(({ children, ...props }, ref) => {
   const validChildren = React.Children.toArray(children).filter((child) => React.isValidElement(child));
   const elements = validChildren.map((child, index) =>
     React.cloneElement(child, {
-      separator: '/',
       isLastChild: validChildren.length === index + 1,
     }),
   );

--- a/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { After } from '@strapi/icons';
+import After from '@strapi/icons/After';
 import { Text } from '../Text';
 import { Box } from '../Box';
 import { Row } from '../Row';

--- a/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Text } from '../Text';
 import { Box } from '../Box';
-import { VisuallyHidden } from '../VisuallyHidden';
 import { useId } from '../helpers/useId';
 
 const BreadCrumbItemWrapper = styled.li`
   display: inline-flex;
+  align-items: center;
 `;
 
 export const BreadCrumbItem = React.forwardRef(({ children, isLastChild, separator }, ref) => {
@@ -33,21 +33,18 @@ BreadCrumbItem.propTypes = {
   separator: PropTypes.string,
 };
 
-export const Breadcrumbs = React.forwardRef(({ label, description, children, ...props }, ref) => {
+export const Breadcrumbs = React.forwardRef(({ children, ...props }, ref) => {
   const breadCrumbsId = useId('breadcrumbs');
-  const descriptionId = useId('description');
   const validChildren = React.Children.toArray(children).filter((child) => React.isValidElement(child));
   const elements = validChildren.map((child, index) =>
     React.cloneElement(child, {
       separator: '/',
-      spacing: 1,
       isLastChild: validChildren.length === index + 1,
     }),
   );
 
   return (
-    <nav id={breadCrumbsId} aria-describedby={descriptionId} aria-label={label} ref={ref} {...props}>
-      <VisuallyHidden id={descriptionId}>{description}</VisuallyHidden>
+    <nav id={breadCrumbsId} ref={ref} {...props}>
       <ol>{elements}</ol>
     </nav>
   );
@@ -55,12 +52,6 @@ export const Breadcrumbs = React.forwardRef(({ label, description, children, ...
 
 Breadcrumbs.displayName = 'Breadcrumbs';
 
-Breadcrumbs.defaultProps = {
-  description: undefined,
-  label: undefined,
-};
 Breadcrumbs.propTypes = {
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)]).isRequired,
-  description: PropTypes.string,
-  label: PropTypes.string,
 };

--- a/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
@@ -4,11 +4,10 @@ import styled from 'styled-components';
 import { After } from '@strapi/icons';
 import { Text } from '../Text';
 import { Box } from '../Box';
+import { Row } from '../Row';
 import { useId } from '../helpers/useId';
 
-const CrumbWrapper = styled.li`
-  display: inline-flex;
-  align-items: center;
+const CrumbWrapper = styled(Row)`
   svg {
     height: 10px;
     width: 10px;
@@ -16,46 +15,35 @@ const CrumbWrapper = styled.li`
   svg path {
     fill: ${({ theme }) => theme.colors.neutral300};
   }
+  :last-of-type ${Box} {
+    display: none;
+  }
 `;
 
-export const Crumb = React.forwardRef(({ children, isLastChild }, ref) => {
+export const Crumb = ({ children }) => {
   return (
-    <CrumbWrapper ref={ref}>
+    <CrumbWrapper inline as="li">
       <Text highlighted color="neutral800">
         {children}
       </Text>
-      {!isLastChild && (
-        <Box paddingLeft={3} paddingRight={3}>
-          <After />
-        </Box>
-      )}
+      <Box paddingLeft={3} paddingRight={3}>
+        <After />
+      </Box>
     </CrumbWrapper>
   );
-});
-Crumb.displayName = 'Crumb';
-Crumb.defaultProps = {
-  isLastChild: false,
 };
+
+Crumb.displayName = 'Crumb';
+
 Crumb.propTypes = {
   children: PropTypes.string.isRequired,
-  isLastChild: PropTypes.bool,
 };
 
-export const Breadcrumbs = React.forwardRef(({ children, ...props }, ref) => {
-  const breadCrumbsId = useId('breadcrumbs');
+export const Breadcrumbs = ({ children }) => {
   const validChildren = React.Children.toArray(children).filter((child) => React.isValidElement(child));
-  const elements = validChildren.map((child, index) =>
-    React.cloneElement(child, {
-      isLastChild: validChildren.length === index + 1,
-    }),
-  );
 
-  return (
-    <nav id={breadCrumbsId} ref={ref} {...props}>
-      <ol>{elements}</ol>
-    </nav>
-  );
-});
+  return <ol>{validChildren}</ol>;
+};
 
 Breadcrumbs.displayName = 'Breadcrumbs';
 

--- a/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
@@ -5,7 +5,6 @@ import { After } from '@strapi/icons';
 import { Text } from '../Text';
 import { Box } from '../Box';
 import { Row } from '../Row';
-import { useId } from '../helpers/useId';
 
 const CrumbWrapper = styled(Row)`
   svg {
@@ -34,19 +33,15 @@ export const Crumb = ({ children }) => {
 };
 
 Crumb.displayName = 'Crumb';
-
 Crumb.propTypes = {
   children: PropTypes.string.isRequired,
 };
+const crumbType = PropTypes.shape({ type: PropTypes.oneOf([Crumb]) });
 
-export const Breadcrumbs = ({ children }) => {
-  const validChildren = React.Children.toArray(children).filter((child) => React.isValidElement(child));
-
-  return <ol>{validChildren}</ol>;
-};
+export const Breadcrumbs = ({ children }) => <ol>{children}</ol>;
 
 Breadcrumbs.displayName = 'Breadcrumbs';
 
 Breadcrumbs.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)]).isRequired,
+  children: PropTypes.oneOfType([PropTypes.arrayOf(crumbType), crumbType]).isRequired,
 };

--- a/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.stories.mdx
+++ b/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.stories.mdx
@@ -27,7 +27,7 @@ Description...
 
 <Canvas>
   <Story name="base">
-    <Breadcrumbs>
+    <Breadcrumbs label='Category model, name field'>
       <Crumb>Category</Crumb>
       <Crumb>Name</Crumb>
     </Breadcrumbs>

--- a/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.stories.mdx
+++ b/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.stories.mdx
@@ -2,7 +2,7 @@
 
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import { withDesign } from 'storybook-addon-designs';
-import { Breadcrumbs, BreadCrumbItem } from './Breadcrumbs';
+import { Breadcrumbs, Crumb } from './Breadcrumbs';
 import { Text } from '../Text';
 
 <Meta
@@ -28,9 +28,8 @@ Description...
 <Canvas>
   <Story name="base">
     <Breadcrumbs>
-      <BreadCrumbItem>Home</BreadCrumbItem>
-      <BreadCrumbItem>first</BreadCrumbItem>
-      <BreadCrumbItem>second</BreadCrumbItem>
+      <Crumb>Category</Crumb>
+      <Crumb>Name</Crumb>
     </Breadcrumbs>
   </Story>
 </Canvas>

--- a/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.stories.mdx
+++ b/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.stories.mdx
@@ -1,0 +1,36 @@
+<!--- Breadcrumbs.stories.mdx --->
+
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { withDesign } from 'storybook-addon-designs';
+import { Breadcrumbs, BreadCrumbItem } from './Breadcrumbs';
+import { Text } from '../Text';
+
+<Meta
+  title="Breadcrumbs"
+  component={Breadcrumbs}
+  decorators={[withDesign]}
+  parameters={{
+    design: {
+      type: 'figma',
+      url: 'TODO: Fill the according figma file',
+    },
+  }}
+/>
+
+# Breadcrumbs
+
+This is the doc of the `Breadcrumbs` component
+
+## Breadcrumbs
+
+Description...
+
+<Canvas>
+  <Story name="base">
+    <Breadcrumbs>
+      <BreadCrumbItem>Home</BreadCrumbItem>
+      <BreadCrumbItem>first</BreadCrumbItem>
+      <BreadCrumbItem>second</BreadCrumbItem>
+    </Breadcrumbs>
+  </Story>
+</Canvas>

--- a/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.e2e.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.e2e.js
@@ -1,0 +1,13 @@
+import { injectAxe, checkA11y } from 'axe-playwright';
+
+describe('Breadcrumbs', () => {
+  beforeEach(async () => {
+    // This is the URL of the Storybook Iframe
+    await page.goto('http://localhost:6006/iframe.html?id=breadcrumbs--base&viewMode=story');
+    await injectAxe(page);
+  });
+
+  it('triggers axe on the document', async () => {
+    await checkA11y(page);
+  });
+});

--- a/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.spec.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.spec.js
@@ -5,14 +5,6 @@ import { Breadcrumbs, Crumb } from '../Breadcrumbs';
 import { ThemeProvider } from '../../ThemeProvider';
 import { lightTheme } from '../../themes';
 
-jest.mock('@strapi/icons', () => ({
-  After: () => <span>After</span>,
-}));
-
-jest.mock('../../helpers/genId', () => ({
-  genId: () => 123,
-}));
-
 describe('Breadcrumbs', () => {
   it('snapshots the component', () => {
     const { container } = render(
@@ -97,9 +89,18 @@ describe('Breadcrumbs', () => {
             <div
               class="c4 c5"
             >
-              <span>
-                After
-              </span>
+              <svg
+                fill="none"
+                height="1em"
+                viewBox="0 0 10 16"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
+                  fill="#32324D"
+                />
+              </svg>
             </div>
           </li>
           <li
@@ -114,9 +115,18 @@ describe('Breadcrumbs', () => {
             <div
               class="c4 c5"
             >
-              <span>
-                After
-              </span>
+              <svg
+                fill="none"
+                height="1em"
+                viewBox="0 0 10 16"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
+                  fill="#32324D"
+                />
+              </svg>
             </div>
           </li>
           <li
@@ -131,9 +141,18 @@ describe('Breadcrumbs', () => {
             <div
               class="c4 c5"
             >
-              <span>
-                After
-              </span>
+              <svg
+                fill="none"
+                height="1em"
+                viewBox="0 0 10 16"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
+                  fill="#32324D"
+                />
+              </svg>
             </div>
           </li>
         </ol>

--- a/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.spec.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.spec.js
@@ -26,13 +26,13 @@ describe('Breadcrumbs', () => {
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
-      .c1 {
+      .c2 {
         font-weight: 500;
         font-size: 0.875rem;
         line-height: 1.43;
       }
 
-      .c2 {
+      .c4 {
         padding-right: 12px;
         padding-left: 12px;
       }
@@ -42,71 +42,81 @@ describe('Breadcrumbs', () => {
         display: -webkit-inline-flex;
         display: -ms-inline-flexbox;
         display: inline-flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;
         align-items: center;
       }
 
-      .c0 svg {
+      .c1 svg {
         height: 10px;
         width: 10px;
       }
 
-      .c0 svg path {
+      .c1 svg path {
         fill: #c0c0cf;
       }
 
-      <nav
-        id="breadcrumbs-123"
-      >
-        <ol>
-          <li
-            class="c0"
+      .c1:last-of-type .c3 {
+        display: none;
+      }
+
+      <ol>
+        <li
+          class="c0 c1"
+        >
+          <p
+            class="c2"
+            color="neutral800"
           >
-            <p
-              class="c1"
-              color="neutral800"
-            >
-              Home
-            </p>
-            <div
-              class="c2"
-            >
-              <span>
-                After
-              </span>
-            </div>
-          </li>
-          <li
-            class="c0"
+            Home
+          </p>
+          <div
+            class="c3 c4"
           >
-            <p
-              class="c1"
-              color="neutral800"
-            >
-              first
-            </p>
-            <div
-              class="c2"
-            >
-              <span>
-                After
-              </span>
-            </div>
-          </li>
-          <li
-            class="c0"
+            <span>
+              After
+            </span>
+          </div>
+        </li>
+        <li
+          class="c0 c1"
+        >
+          <p
+            class="c2"
+            color="neutral800"
           >
-            <p
-              class="c1"
-              color="neutral800"
-            >
-              second
-            </p>
-          </li>
-        </ol>
-      </nav>
+            first
+          </p>
+          <div
+            class="c3 c4"
+          >
+            <span>
+              After
+            </span>
+          </div>
+        </li>
+        <li
+          class="c0 c1"
+        >
+          <p
+            class="c2"
+            color="neutral800"
+          >
+            second
+          </p>
+          <div
+            class="c3 c4"
+          >
+            <span>
+              After
+            </span>
+          </div>
+        </li>
+      </ol>
     `);
   });
 });

--- a/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.spec.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.spec.js
@@ -4,6 +4,10 @@ import { Breadcrumbs, BreadCrumbItem } from '../Breadcrumbs';
 import { ThemeProvider } from '../../ThemeProvider';
 import { lightTheme } from '../../themes';
 
+jest.mock('../../helpers/genId', () => ({
+  genId: () => 123,
+}));
+
 describe('Breadcrumbs', () => {
   it('snapshots the component', () => {
     const { container } = render(
@@ -40,7 +44,7 @@ describe('Breadcrumbs', () => {
       }
 
       <nav
-        id="breadcrumbs-e448d77d-f81c-418e-8c79-fc160f2a8d0c"
+        id="breadcrumbs-123"
       >
         <ol>
           <li

--- a/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.spec.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.spec.js
@@ -1,8 +1,13 @@
+/* eslint-disable react/display-name */
 import * as React from 'react';
 import { render } from '@testing-library/react';
-import { Breadcrumbs, BreadCrumbItem } from '../Breadcrumbs';
+import { Breadcrumbs, Crumb } from '../Breadcrumbs';
 import { ThemeProvider } from '../../ThemeProvider';
 import { lightTheme } from '../../themes';
+
+jest.mock('@strapi/icons', () => ({
+  After: () => <span>After</span>,
+}));
 
 jest.mock('../../helpers/genId', () => ({
   genId: () => 123,
@@ -13,23 +18,23 @@ describe('Breadcrumbs', () => {
     const { container } = render(
       <ThemeProvider theme={lightTheme}>
         <Breadcrumbs>
-          <BreadCrumbItem>Home</BreadCrumbItem>
-          <BreadCrumbItem>first</BreadCrumbItem>
-          <BreadCrumbItem>second</BreadCrumbItem>
+          <Crumb>Home</Crumb>
+          <Crumb>first</Crumb>
+          <Crumb>second</Crumb>
         </Breadcrumbs>
       </ThemeProvider>,
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
       .c1 {
-        font-weight: 400;
+        font-weight: 500;
         font-size: 0.875rem;
         line-height: 1.43;
       }
 
       .c2 {
-        padding-right: 4px;
-        padding-left: 4px;
+        padding-right: 12px;
+        padding-left: 12px;
       }
 
       .c0 {
@@ -43,6 +48,15 @@ describe('Breadcrumbs', () => {
         align-items: center;
       }
 
+      .c0 svg {
+        height: 10px;
+        width: 10px;
+      }
+
+      .c0 svg path {
+        fill: #c0c0cf;
+      }
+
       <nav
         id="breadcrumbs-123"
       >
@@ -52,13 +66,16 @@ describe('Breadcrumbs', () => {
           >
             <p
               class="c1"
+              color="neutral800"
             >
               Home
             </p>
             <div
               class="c2"
             >
-              /
+              <span>
+                After
+              </span>
             </div>
           </li>
           <li
@@ -66,13 +83,16 @@ describe('Breadcrumbs', () => {
           >
             <p
               class="c1"
+              color="neutral800"
             >
               first
             </p>
             <div
               class="c2"
             >
-              /
+              <span>
+                After
+              </span>
             </div>
           </li>
           <li
@@ -80,6 +100,7 @@ describe('Breadcrumbs', () => {
           >
             <p
               class="c1"
+              color="neutral800"
             >
               second
             </p>

--- a/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.spec.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.spec.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Breadcrumbs } from '../Breadcrumbs';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+
+describe('Breadcrumbs', () => {
+  it('snapshots the component', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Breadcrumbs />
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(``);
+  });
+});

--- a/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.spec.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.spec.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
-import { Breadcrumbs } from '../Breadcrumbs';
+import { Breadcrumbs, BreadCrumbItem } from '../Breadcrumbs';
 import { ThemeProvider } from '../../ThemeProvider';
 import { lightTheme } from '../../themes';
 
@@ -8,10 +8,80 @@ describe('Breadcrumbs', () => {
   it('snapshots the component', () => {
     const { container } = render(
       <ThemeProvider theme={lightTheme}>
-        <Breadcrumbs />
+        <Breadcrumbs>
+          <BreadCrumbItem>Home</BreadCrumbItem>
+          <BreadCrumbItem>first</BreadCrumbItem>
+          <BreadCrumbItem>second</BreadCrumbItem>
+        </Breadcrumbs>
       </ThemeProvider>,
     );
 
-    expect(container.firstChild).toMatchInlineSnapshot(``);
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c1 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+      }
+
+      .c2 {
+        padding-right: 4px;
+        padding-left: 4px;
+      }
+
+      .c0 {
+        display: -webkit-inline-box;
+        display: -webkit-inline-flex;
+        display: -ms-inline-flexbox;
+        display: inline-flex;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+      }
+
+      <nav
+        id="breadcrumbs-e448d77d-f81c-418e-8c79-fc160f2a8d0c"
+      >
+        <ol>
+          <li
+            class="c0"
+          >
+            <p
+              class="c1"
+            >
+              Home
+            </p>
+            <div
+              class="c2"
+            >
+              /
+            </div>
+          </li>
+          <li
+            class="c0"
+          >
+            <p
+              class="c1"
+            >
+              first
+            </p>
+            <div
+              class="c2"
+            >
+              /
+            </div>
+          </li>
+          <li
+            class="c0"
+          >
+            <p
+              class="c1"
+            >
+              second
+            </p>
+          </li>
+        </ol>
+      </nav>
+    `);
   });
 });

--- a/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.spec.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.spec.js
@@ -17,7 +17,7 @@ describe('Breadcrumbs', () => {
   it('snapshots the component', () => {
     const { container } = render(
       <ThemeProvider theme={lightTheme}>
-        <Breadcrumbs>
+        <Breadcrumbs label="second page">
           <Crumb>Home</Crumb>
           <Crumb>first</Crumb>
           <Crumb>second</Crumb>
@@ -26,18 +26,18 @@ describe('Breadcrumbs', () => {
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
-      .c2 {
+      .c3 {
         font-weight: 500;
         font-size: 0.875rem;
         line-height: 1.43;
       }
 
-      .c4 {
+      .c5 {
         padding-right: 12px;
         padding-left: 12px;
       }
 
-      .c0 {
+      .c1 {
         display: -webkit-inline-box;
         display: -webkit-inline-flex;
         display: -ms-inline-flexbox;
@@ -51,72 +51,93 @@ describe('Breadcrumbs', () => {
         align-items: center;
       }
 
-      .c1 svg {
+      .c0 {
+        border: 0;
+        -webkit-clip: rect(0 0 0 0);
+        clip: rect(0 0 0 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+      }
+
+      .c2 svg {
         height: 10px;
         width: 10px;
       }
 
-      .c1 svg path {
+      .c2 svg path {
         fill: #c0c0cf;
       }
 
-      .c1:last-of-type .c3 {
+      .c2:last-of-type .c4 {
         display: none;
       }
 
-      <ol>
-        <li
-          class="c0 c1"
+      <div>
+        <div
+          class="c0"
         >
-          <p
-            class="c2"
-            color="neutral800"
-          >
-            Home
-          </p>
-          <div
-            class="c3 c4"
-          >
-            <span>
-              After
-            </span>
-          </div>
-        </li>
-        <li
-          class="c0 c1"
+          second page
+        </div>
+        <ol
+          aria-hidden="true"
         >
-          <p
-            class="c2"
-            color="neutral800"
+          <li
+            class="c1 c2"
           >
-            first
-          </p>
-          <div
-            class="c3 c4"
+            <p
+              class="c3"
+              color="neutral800"
+            >
+              Home
+            </p>
+            <div
+              class="c4 c5"
+            >
+              <span>
+                After
+              </span>
+            </div>
+          </li>
+          <li
+            class="c1 c2"
           >
-            <span>
-              After
-            </span>
-          </div>
-        </li>
-        <li
-          class="c0 c1"
-        >
-          <p
-            class="c2"
-            color="neutral800"
+            <p
+              class="c3"
+              color="neutral800"
+            >
+              first
+            </p>
+            <div
+              class="c4 c5"
+            >
+              <span>
+                After
+              </span>
+            </div>
+          </li>
+          <li
+            class="c1 c2"
           >
-            second
-          </p>
-          <div
-            class="c3 c4"
-          >
-            <span>
-              After
-            </span>
-          </div>
-        </li>
-      </ol>
+            <p
+              class="c3"
+              color="neutral800"
+            >
+              second
+            </p>
+            <div
+              class="c4 c5"
+            >
+              <span>
+                After
+              </span>
+            </div>
+          </li>
+        </ol>
+      </div>
     `);
   });
 });

--- a/packages/strapi-design-system/src/Breadcrumbs/index.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/index.js
@@ -1,0 +1,1 @@
+export * from './Breadcrumbs';

--- a/packages/strapi-design-system/src/Row/Row.js
+++ b/packages/strapi-design-system/src/Row/Row.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 export const Row = styled.div`
-  display: flex;
+  display: ${({ inline }) => (inline ? 'inline-flex' : 'flex')};
   flex-direction: ${({ reverse }) => (reverse ? 'row-reverse' : 'row')};
   justify-content: ${({ justifyContent }) => justifyContent};
   align-items: ${({ alignItems }) => alignItems};
@@ -11,6 +11,7 @@ export const Row = styled.div`
 
 Row.defaultProps = {
   alignItems: 'center',
+  inline: false,
   justifyContent: undefined,
   reverse: false,
   wrap: undefined,
@@ -18,6 +19,7 @@ Row.defaultProps = {
 
 Row.propTypes = {
   alignItems: PropTypes.string,
+  inline: PropTypes.bool,
   justifyContent: PropTypes.string,
   reverse: PropTypes.bool,
   wrap: PropTypes.string,

--- a/plop-templates/component.hbs
+++ b/plop-templates/component.hbs
@@ -1,10 +1,10 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React from 'react';
+import PropTypes from 'prop-types';
 
 export const {{name}} = React.forwardRef((props, ref) => {
   return <div ref={ref} {...props} />;
 });
 
-{{name}}.displayName = {{name}};
+{{name}}.displayName = '{{name}}';
 
 {{name}}.propTypes = {};

--- a/plop-templates/unit-test.hbs
+++ b/plop-templates/unit-test.hbs
@@ -12,6 +12,6 @@ describe('{{name}}', () => {
       </ThemeProvider>,
     );
 
-    expect(container.firstChild).toMatchInlineSnapshot(``);
+    expect(container.firstChild).toMatchInlineSnapshot();
   });
 });


### PR DESCRIPTION
Signed-off-by: HichamELBSI <elabbassih@gmail.com>

# Add breadcrumbs

## Description
This is a draft for the breadcrumbs component. Let's check the API before going forward 😄 

## Demo
Example on : https://design-system-git-breadcrumbs-strapijs.vercel.app/?path=/story/breadcrumbs--base

## API
```jsx
<Breadcrumbs label="Second page">
   <BreadCrumbItem>Home</BreadCrumbItem>
   <BreadCrumbItem>first</BreadCrumbItem>
   <BreadCrumbItem>second</BreadCrumbItem>
</Breadcrumbs>
```

## Screenshot

![Screenshot 2021-05-12 at 10 43 23](https://user-images.githubusercontent.com/7756284/117945727-e5b9b880-b30e-11eb-949d-e28b58da9fa8.png)