### PR TITLE
Fixing tooltip for description

### DIFF
--- a/packages/strapi-design-system/src/Tooltip/Tooltip.js
+++ b/packages/strapi-design-system/src/Tooltip/Tooltip.js
@@ -13,7 +13,7 @@ const TooltipWrapper = styled(Box)`
   display: ${({ visible }) => (visible ? 'revert' : 'none')};
 `;
 
-export const Tooltip = ({ children, content, delay, position, ...props }) => {
+export const Tooltip = ({ children, label, description, delay, position, ...props }) => {
   const tooltipId = useId('tooltip');
   const { visible, ...tooltipHandlers } = useTooltipHandlers(delay);
   const { tooltipWrapperRef, toggleSourceRef } = useTooltipLayout(visible, position);
@@ -21,7 +21,8 @@ export const Tooltip = ({ children, content, delay, position, ...props }) => {
   const childrenClone = React.cloneElement(children, {
     ref: toggleSourceRef,
     tabIndex: 0,
-    'aria-describedby': visible ? tooltipId : undefined,
+    'aria-labelledby': label ? tooltipId : undefined,
+    'aria-describedby': visible && description ? tooltipId : undefined,
     ...tooltipHandlers,
   });
 
@@ -39,7 +40,7 @@ export const Tooltip = ({ children, content, delay, position, ...props }) => {
           {...props}
         >
           <Text small={true} highlighted={true} textColor="neutral0">
-            {content}
+            {label || description}
           </Text>
         </TooltipWrapper>
       </Portal>
@@ -52,11 +53,14 @@ export const Tooltip = ({ children, content, delay, position, ...props }) => {
 Tooltip.defaultProps = {
   delay: 500,
   position: 'top',
+  label: undefined,
+  description: undefined,
 };
 
 Tooltip.propTypes = {
   children: PropTypes.node.isRequired,
-  content: PropTypes.string.isRequired,
   delay: PropTypes.number,
+  description: PropTypes.string,
+  label: PropTypes.string,
   position: PropTypes.oneOf(['top', 'left', 'bottom', 'right']),
 };

--- a/packages/strapi-design-system/src/Tooltip/Tooltip.js
+++ b/packages/strapi-design-system/src/Tooltip/Tooltip.js
@@ -22,7 +22,7 @@ export const Tooltip = ({ children, label, description, delay, position, ...prop
     ref: toggleSourceRef,
     tabIndex: 0,
     'aria-labelledby': label ? tooltipId : undefined,
-    'aria-describedby': visible && description ? tooltipId : undefined,
+    'aria-describedby': description ? tooltipId : undefined,
     ...tooltipHandlers,
   });
 

--- a/packages/strapi-design-system/src/Tooltip/Tooltip.stories.mdx
+++ b/packages/strapi-design-system/src/Tooltip/Tooltip.stories.mdx
@@ -36,7 +36,7 @@ Description...
         voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
         sunt in culpa qui officia deserunt mollit anim id est laborum.
       </p>
-      <Tooltip content="Content of the tooltip">
+      <Tooltip description="Content of the tooltip">
         <button>Show tooltip</button>
       </Tooltip>
       <p>
@@ -57,7 +57,7 @@ Description...
         voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
         sunt in culpa qui officia deserunt mollit anim id est laborum.
       </p>
-      <Tooltip content="Smaller">
+      <Tooltip description="Smaller">
         <span>Show tooltip</span>
       </Tooltip>
       <p>
@@ -128,22 +128,22 @@ Description...
       style={{ marginTop: '200px' }}
     >
       <Box area="first">
-        <Tooltip content="First content">
+        <Tooltip description="First content">
           <button>First</button>
         </Tooltip>
       </Box>
       <Box area="second">
-        <Tooltip content="Second content" position="bottom">
+        <Tooltip description="Second content" position="bottom">
           <button>Second</button>
         </Tooltip>
       </Box>
       <Box area="third">
-        <Tooltip content="Third content" position="right">
+        <Tooltip description="Third content" position="right">
           <button>Third</button>
         </Tooltip>
       </Box>
       <Box area="fourth">
-        <Tooltip content="Fourth content" position="left">
+        <Tooltip description="Fourth content" position="left">
           <button>A longer CTA than the content</button>
         </Tooltip>
       </Box>
@@ -155,5 +155,15 @@ Description...
       voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
       in culpa qui officia deserunt mollit anim id est laborum.
     </p>
+  </Story>
+  <Story name="description">
+    <Tooltip description="This is the description">
+      <button>This is a label with a description in the tooltip</button>
+    </Tooltip>
+  </Story>
+  <Story name="label">
+    <Tooltip label="This is the label">
+      <button>+</button>
+    </Tooltip>
   </Story>
 </Canvas>

--- a/packages/strapi-design-system/src/Tooltip/__tests__/Tooltip.spec.js
+++ b/packages/strapi-design-system/src/Tooltip/__tests__/Tooltip.spec.js
@@ -50,14 +50,13 @@ describe('Tooltip', () => {
         >
           <div
             class="c0 c1"
+            content="Content of the tooltip fefe"
             id="tooltip-123"
             role="tooltip"
           >
             <p
               class="c2"
-            >
-              Content of the tooltip fefe
-            </p>
+            />
           </div>
         </div>
       </body>
@@ -79,7 +78,6 @@ describe('Tooltip', () => {
       <body>
         <div>
           <button
-            aria-describedby="tooltip-123"
             tabindex="0"
           >
             Show tooltip
@@ -108,15 +106,14 @@ describe('Tooltip', () => {
         >
           <div
             class="c0 c1"
+            content="Content of the tooltip fefe"
             id="tooltip-123"
             role="tooltip"
             style="left: 0px; top: -8px;"
           >
             <p
               class="c2"
-            >
-              Content of the tooltip fefe
-            </p>
+            />
           </div>
         </div>
       </body>

--- a/packages/strapi-design-system/src/Tooltip/__tests__/Tooltip.spec.js
+++ b/packages/strapi-design-system/src/Tooltip/__tests__/Tooltip.spec.js
@@ -12,7 +12,7 @@ describe('Tooltip', () => {
   it('snapshots document.body when the tooltip is not shown (aria-describedby does not exist)', () => {
     render(
       <ThemeProvider theme={lightTheme}>
-        <Tooltip content="Content of the tooltip fefe">
+        <Tooltip description="Content of the tooltip fefe">
           <button>Show tooltip</button>
         </Tooltip>
       </ThemeProvider>,
@@ -40,6 +40,7 @@ describe('Tooltip', () => {
       <body>
         <div>
           <button
+            aria-describedby="tooltip-123"
             tabindex="0"
           >
             Show tooltip
@@ -50,13 +51,14 @@ describe('Tooltip', () => {
         >
           <div
             class="c0 c1"
-            content="Content of the tooltip fefe"
             id="tooltip-123"
             role="tooltip"
           >
             <p
               class="c2"
-            />
+            >
+              Content of the tooltip fefe
+            </p>
           </div>
         </div>
       </body>
@@ -66,7 +68,7 @@ describe('Tooltip', () => {
   it('snapshots document.body when the button is focused (aria-describedby exists)', () => {
     render(
       <ThemeProvider theme={lightTheme}>
-        <Tooltip content="Content of the tooltip fefe">
+        <Tooltip description="Content of the tooltip fefe">
           <button>Show tooltip</button>
         </Tooltip>
       </ThemeProvider>,
@@ -78,6 +80,7 @@ describe('Tooltip', () => {
       <body>
         <div>
           <button
+            aria-describedby="tooltip-123"
             tabindex="0"
           >
             Show tooltip
@@ -106,14 +109,74 @@ describe('Tooltip', () => {
         >
           <div
             class="c0 c1"
-            content="Content of the tooltip fefe"
             id="tooltip-123"
             role="tooltip"
             style="left: 0px; top: -8px;"
           >
             <p
               class="c2"
-            />
+            >
+              Content of the tooltip fefe
+            </p>
+          </div>
+        </div>
+      </body>
+    `);
+  });
+
+  it('snapshots document.body with a label', () => {
+    render(
+      <ThemeProvider theme={lightTheme}>
+        <Tooltip label="Content of the tooltip fefe">
+          <button>+</button>
+        </Tooltip>
+      </ThemeProvider>,
+    );
+
+    fireEvent.focus(screen.getByText('+'));
+
+    expect(document.body).toMatchInlineSnapshot(`
+      <body>
+        <div>
+          <button
+            aria-labelledby="tooltip-123"
+            tabindex="0"
+          >
+            +
+          </button>
+        </div>
+        .c0 {
+        background: #212134;
+        padding: 8px;
+        border-radius: 4px;
+      }
+
+      .c2 {
+        font-weight: 500;
+        font-size: 0.75rem;
+        line-height: 1.33;
+        color: #ffffff;
+      }
+
+      .c1 {
+        position: absolute;
+        display: revert;
+      }
+
+      <div
+          data-react-portal="true"
+        >
+          <div
+            class="c0 c1"
+            id="tooltip-123"
+            role="tooltip"
+            style="left: 0px; top: -8px;"
+          >
+            <p
+              class="c2"
+            >
+              Content of the tooltip fefe
+            </p>
           </div>
         </div>
       </body>


### PR DESCRIPTION
# Fixing and simplifying tooltip

## Description

Tooltip can provide a primary label OR an aditional description.

## Demo
Example on : [deployed story link]

## API
[api details]

```jsx
<Tooltip description="This is the description">
  <button>This is a label with a description in the tooltip</button>
</Tooltip>

<Tooltip label="This is the label">
  <button>+</button>
</Tooltip>
```

## Voiceover

![2021-05-10 17 02 02](https://user-images.githubusercontent.com/3874873/117680550-8f833300-b1b1-11eb-85a7-c9d37fb22613.gif)

![2021-05-10 17 02 18](https://user-images.githubusercontent.com/3874873/117680571-9611aa80-b1b1-11eb-8e5e-bbcb74e41cc6.gif)

