### PR TITLE
Add a link component

### DIFF
--- a/packages/strapi-design-system/src/Link/Link.js
+++ b/packages/strapi-design-system/src/Link/Link.js
@@ -48,7 +48,7 @@ export const Link = ({ href, to, children, disabled, leftIcon, rightIcon, ...pro
   );
 };
 
-Link.displayName = Link;
+Link.displayName = 'Link';
 
 Link.defaultProps = {
   href: undefined,
@@ -59,8 +59,16 @@ Link.defaultProps = {
 Link.propTypes = {
   children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
-  href: PropTypes.string,
+  href: (props) => {
+    if (!props.disabled && !props.to && !props.href) {
+      return new Error('href must be defined');
+    }
+  },
   leftIcon: PropTypes.element,
   rightIcon: PropTypes.element,
-  to: PropTypes.string,
+  to: (props) => {
+    if (!props.disabled && !props.href && !props.to) {
+      return new Error('to must be defined');
+    }
+  },
 };

--- a/packages/strapi-design-system/src/Link/Link.js
+++ b/packages/strapi-design-system/src/Link/Link.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { TableLabel } from '../Text';
+import { Box } from '../Box';
+
+const LinkWrapper = styled.a`
+  text-transform: uppercase;
+  text-decoration: none;
+  pointer-events: ${({ disabled }) => (disabled ? 'none' : undefined)};
+
+  svg path {
+    fill: ${({ disabled, theme }) => (disabled ? theme.colors.neutral600 : theme.colors.primary600)};
+  }
+
+  &:hover,
+  &:active {
+    color: ${({ theme }) => theme.colors.primary800};
+  }
+`;
+
+// TODO: make sure to use the link from the router library chosen
+export const Link = ({ href, to, children, disabled, leftIcon, rightIcon, ...props }) => {
+  const linkHref = disabled ? '#' : href || to;
+  const target = href ? '_blank' : undefined;
+  const rel = href ? 'noreferrer noopener' : undefined;
+
+  return (
+    <LinkWrapper target={target} rel={rel} href={linkHref} disabled={disabled} {...props}>
+      <TableLabel textColor={disabled ? 'neutral600' : 'primary600'} as="span">
+        {leftIcon && (
+          <Box as="span" aria-hidden={true} paddingRight={2}>
+            {leftIcon}
+          </Box>
+        )}
+        {children}
+        {rightIcon && (
+          <Box as="span" aria-hidden={true} paddingLeft={2}>
+            {rightIcon}
+          </Box>
+        )}
+      </TableLabel>
+    </LinkWrapper>
+  );
+};
+
+Link.displayName = Link;
+
+Link.defaultProps = {
+  href: undefined,
+  to: undefined,
+  disabled: false,
+};
+
+Link.propTypes = {
+  children: PropTypes.node.isRequired,
+  disabled: PropTypes.bool,
+  href: PropTypes.string,
+  leftIcon: PropTypes.element,
+  rightIcon: PropTypes.element,
+  to: PropTypes.string,
+};

--- a/packages/strapi-design-system/src/Link/Link.js
+++ b/packages/strapi-design-system/src/Link/Link.js
@@ -13,6 +13,10 @@ const LinkWrapper = styled.a`
     fill: ${({ disabled, theme }) => (disabled ? theme.colors.neutral600 : theme.colors.primary600)};
   }
 
+  svg {
+    font-size: ${10 / 16}rem;
+  }
+
   &:hover,
   &:active {
     color: ${({ theme }) => theme.colors.primary800};

--- a/packages/strapi-design-system/src/Link/Link.stories.mdx
+++ b/packages/strapi-design-system/src/Link/Link.stories.mdx
@@ -1,0 +1,52 @@
+<!--- Link.stories.mdx --->
+
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { withDesign } from 'storybook-addon-designs';
+import { BackIcon, NextIcon } from '@strapi/icons';
+import { Link } from './Link';
+import { Stack } from '../Stack';
+
+<Meta
+  title="Link"
+  component={Link}
+  decorators={[withDesign]}
+  parameters={{
+    design: {
+      type: 'figma',
+      url: 'TODO: Fill the according figma file',
+    },
+  }}
+/>
+
+# Link
+
+This is the doc of the `Link` component
+
+## Link
+
+Description...
+
+<Canvas>
+  <Story name="base">
+    <Stack size={5}>
+      <div>
+        <Link href="https://strapi.io/">External link</Link>
+      </div>
+      <div>
+        <Link to="/somewhere-internal" leftIcon={<BackIcon />}>
+          Internal link
+        </Link>
+      </div>
+      <div>
+        <Link href="https://strapi.io/" rightIcon={<NextIcon />}>
+          External disabled link
+        </Link>
+      </div>
+      <div>
+        <Link to="/somewhere-internal" disabled leftIcon={<BackIcon />} rightIcon={<NextIcon />}>
+          Internal disabled link
+        </Link>
+      </div>
+    </Stack>
+  </Story>
+</Canvas>

--- a/packages/strapi-design-system/src/Link/__tests__/Link.e2e.js
+++ b/packages/strapi-design-system/src/Link/__tests__/Link.e2e.js
@@ -1,0 +1,13 @@
+import { injectAxe, checkA11y } from 'axe-playwright';
+
+describe('Link', () => {
+  beforeEach(async () => {
+    // This is the URL of the Storybook Iframe
+    await page.goto('http://localhost:6006/iframe.html?id=link--base&viewMode=story');
+    await injectAxe(page);
+  });
+
+  it('triggers axe on the document', async () => {
+    await checkA11y(page);
+  });
+});

--- a/packages/strapi-design-system/src/Link/__tests__/Link.spec.js
+++ b/packages/strapi-design-system/src/Link/__tests__/Link.spec.js
@@ -42,6 +42,10 @@ describe('Link', () => {
         fill: #4945ff;
       }
 
+      .c0 svg {
+        font-size: 0.625rem;
+      }
+
       <a
         class="c0"
         href="https://strapi.io/"
@@ -102,6 +106,10 @@ describe('Link', () => {
 
       .c0 svg path {
         fill: #4945ff;
+      }
+
+      .c0 svg {
+        font-size: 0.625rem;
       }
 
       <a
@@ -179,6 +187,10 @@ describe('Link', () => {
 
       .c0 svg path {
         fill: #666687;
+      }
+
+      .c0 svg {
+        font-size: 0.625rem;
       }
 
       <a

--- a/packages/strapi-design-system/src/Link/__tests__/Link.spec.js
+++ b/packages/strapi-design-system/src/Link/__tests__/Link.spec.js
@@ -1,0 +1,213 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Link } from '../Link';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+
+describe('Link', () => {
+  it('snapshots the component with an external link', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Link href="https://strapi.io/">External link</Link>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c1 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #4945ff;
+      }
+
+      .c2 {
+        font-weight: 600;
+        line-height: 1.14;
+      }
+
+      .c3 {
+        font-weight: 600;
+        font-size: 0.6875rem;
+        line-height: 1.45;
+        text-transform: uppercase;
+      }
+
+      .c0 {
+        text-transform: uppercase;
+        -webkit-text-decoration: none;
+        text-decoration: none;
+      }
+
+      .c0 svg path {
+        fill: #4945ff;
+      }
+
+      <a
+        class="c0"
+        href="https://strapi.io/"
+        rel="noreferrer noopener"
+        target="_blank"
+      >
+        <span
+          class="c1 c2 c3"
+        >
+          External link
+        </span>
+      </a>
+    `);
+  });
+
+  it('snapshots the component with right and left icons', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Link to="https://strapi.io/" leftIcon={<span>Left</span>} rightIcon={<span>Right</span>}>
+          External link
+        </Link>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c1 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #4945ff;
+      }
+
+      .c2 {
+        font-weight: 600;
+        line-height: 1.14;
+      }
+
+      .c3 {
+        font-weight: 600;
+        font-size: 0.6875rem;
+        line-height: 1.45;
+        text-transform: uppercase;
+      }
+
+      .c4 {
+        padding-right: 8px;
+      }
+
+      .c5 {
+        padding-left: 8px;
+      }
+
+      .c0 {
+        text-transform: uppercase;
+        -webkit-text-decoration: none;
+        text-decoration: none;
+      }
+
+      .c0 svg path {
+        fill: #4945ff;
+      }
+
+      <a
+        class="c0"
+        href="https://strapi.io/"
+      >
+        <span
+          class="c1 c2 c3"
+        >
+          <span
+            aria-hidden="true"
+            class="c4"
+          >
+            <span>
+              Left
+            </span>
+          </span>
+          External link
+          <span
+            aria-hidden="true"
+            class="c5"
+          >
+            <span>
+              Right
+            </span>
+          </span>
+        </span>
+      </a>
+    `);
+  });
+
+  it('snapshots the component with right and left icons and disabled state', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Link disabled to="https://strapi.io/" leftIcon={<span>Left</span>} rightIcon={<span>Right</span>}>
+          External link
+        </Link>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c1 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #666687;
+      }
+
+      .c2 {
+        font-weight: 600;
+        line-height: 1.14;
+      }
+
+      .c3 {
+        font-weight: 600;
+        font-size: 0.6875rem;
+        line-height: 1.45;
+        text-transform: uppercase;
+      }
+
+      .c4 {
+        padding-right: 8px;
+      }
+
+      .c5 {
+        padding-left: 8px;
+      }
+
+      .c0 {
+        text-transform: uppercase;
+        -webkit-text-decoration: none;
+        text-decoration: none;
+        pointer-events: none;
+      }
+
+      .c0 svg path {
+        fill: #666687;
+      }
+
+      <a
+        class="c0"
+        disabled=""
+        href="#"
+      >
+        <span
+          class="c1 c2 c3"
+        >
+          <span
+            aria-hidden="true"
+            class="c4"
+          >
+            <span>
+              Left
+            </span>
+          </span>
+          External link
+          <span
+            aria-hidden="true"
+            class="c5"
+          >
+            <span>
+              Right
+            </span>
+          </span>
+        </span>
+      </a>
+    `);
+  });
+});

--- a/packages/strapi-design-system/src/Link/index.js
+++ b/packages/strapi-design-system/src/Link/index.js
@@ -1,0 +1,1 @@
+export * from './Link';


### PR DESCRIPTION
# Link

## Description

Add a Link component.

⚠️ the neutral400 color and the neutral500 color were too light for the disabled state. I had to switch to neutral600 to fix the constrast error.

## Demo

Example on :https://design-system-git-add-link-strapijs.vercel.app/?path=/story/link--base

## API

Internal links

```jsx
<Link to="/somewhere-internal" disabled leftIcon={<BackIcon />} rightIcon={<NextIcon />}>
  Internal disabled link
</Link>
```

External links

```jsx
<Link href="https://strapi.io" disabled leftIcon={<BackIcon />} rightIcon={<NextIcon />}>
  External disabled link
</Link>
```

## Screenshots

<img width="337" alt="Screenshot 2021-05-11 at 09 10 30" src="https://user-images.githubusercontent.com/3874873/117773582-c5b7c580-b238-11eb-9c1b-ef0ef61490c3.png">
