### PR TITLE
Add Main and SkipToContent

### DIFF
--- a/packages/strapi-design-system/.storybook/preview.js
+++ b/packages/strapi-design-system/.storybook/preview.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { ThemeProvider } from '../src/ThemeProvider';
 import { VisuallyHidden } from '../src/VisuallyHidden';
 import { lightTheme } from '../src/themes/light-theme';
+import { Main, SkipToContent } from '../src/Main';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -10,14 +11,15 @@ export const parameters = {
 export const decorators = [
   (Story) => (
     <ThemeProvider theme={lightTheme}>
-      <main>
+      <SkipToContent>Skip to main content</SkipToContent>
+      <Main labelledBy="main">
         <VisuallyHidden>
           {/* Necessary in order to prevent axe core from providing errors on main / heading */}
-          <h1>Storybook story</h1>
+          <h1 id="main">This is a storybook story</h1>
         </VisuallyHidden>
 
         <Story />
-      </main>
+      </Main>
     </ThemeProvider>
   ),
 ];

--- a/packages/strapi-design-system/.storybook/preview.js
+++ b/packages/strapi-design-system/.storybook/preview.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { ThemeProvider } from '../src/ThemeProvider';
 import { VisuallyHidden } from '../src/VisuallyHidden';
 import { lightTheme } from '../src/themes/light-theme';
-import { Main, SkipToContent } from '../src/Main';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -11,15 +10,14 @@ export const parameters = {
 export const decorators = [
   (Story) => (
     <ThemeProvider theme={lightTheme}>
-      <SkipToContent>Skip to main content</SkipToContent>
-      <Main labelledBy="main">
+      <main>
         <VisuallyHidden>
           {/* Necessary in order to prevent axe core from providing errors on main / heading */}
-          <h1 id="main">This is a storybook story</h1>
+          <h1>Storybook story</h1>
         </VisuallyHidden>
 
         <Story />
-      </Main>
+      </main>
     </ThemeProvider>
   ),
 ];

--- a/packages/strapi-design-system/src/Main/Main.js
+++ b/packages/strapi-design-system/src/Main/Main.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const Main = ({ labelledBy, ...props }) => {
+  return <main aria-labelledby={labelledBy} id="main-content" {...props} />;
+};
+
+Main.propTypes = {
+  labelledBy: PropTypes.string.isRequired,
+};

--- a/packages/strapi-design-system/src/Main/SkipToContent.js
+++ b/packages/strapi-design-system/src/Main/SkipToContent.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import PropTypes from 'prop-types';
 import { Box } from '../Box';
 
 const AnchorBox = styled(Box)`
@@ -14,8 +15,14 @@ const AnchorBox = styled(Box)`
   }
 `;
 
-export const SkipToContent = (props) => {
+export const SkipToContent = ({ children }) => {
   return (
-    <AnchorBox as="a" href="#main-content" background="primary600" color="neutral0" padding={3} hasRadius {...props} />
+    <AnchorBox as="a" href="#main-content" background="primary600" color="neutral0" padding={3} hasRadius>
+      {children}
+    </AnchorBox>
   );
+};
+
+SkipToContent.propTypes = {
+  children: PropTypes.node.isRequired,
 };

--- a/packages/strapi-design-system/src/Main/SkipToContent.js
+++ b/packages/strapi-design-system/src/Main/SkipToContent.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Box } from '../Box';
+
+const AnchorBox = styled(Box)`
+  text-decoration: none;
+  position: absolute;
+  left: -100%;
+  top: -100%;
+
+  &:focus {
+    left: ${({ theme }) => theme.spaces[3]};
+    top: ${({ theme }) => theme.spaces[3]};
+  }
+`;
+
+export const SkipToContent = (props) => {
+  return (
+    <AnchorBox as="a" href="#main-content" background="primary600" color="neutral0" padding={3} hasRadius {...props} />
+  );
+};

--- a/packages/strapi-design-system/src/Main/__tests__/Main.spec.js
+++ b/packages/strapi-design-system/src/Main/__tests__/Main.spec.js
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Main } from '../Main';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+import { SkipToContent } from '../SkipToContent';
+
+describe('Main', () => {
+  it('snapshots the component', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <div>
+          <SkipToContent>Skip to main content</SkipToContent>
+          <Main labelledBy="main-title">
+            <h1 id="main-title">Hello world</h1>
+          </Main>
+        </div>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c0 {
+        background: #4945ff;
+        color: #ffffff;
+        padding: 12px;
+        border-radius: 4px;
+      }
+
+      .c1 {
+        -webkit-text-decoration: none;
+        text-decoration: none;
+        position: absolute;
+        left: -100%;
+        top: -100%;
+      }
+
+      .c1:focus {
+        left: 12px;
+        top: 12px;
+      }
+
+      <div>
+        <a
+          class="c0 c1"
+          href="#main-content"
+        >
+          Skip to main content
+        </a>
+        <main
+          aria-labelledby="main-title"
+          id="main-content"
+        >
+          <h1
+            id="main-title"
+          >
+            Hello world
+          </h1>
+        </main>
+      </div>
+    `);
+  });
+});

--- a/packages/strapi-design-system/src/Main/index.js
+++ b/packages/strapi-design-system/src/Main/index.js
@@ -1,0 +1,2 @@
+export * from './Main';
+export * from './SkipToContent';


### PR DESCRIPTION
# Add Main and SkipToContent

## Description

- Add a Main component with a strict id and a required labelledBy prop
- Add a SkipToContent component that is available when tabbing for the first time on a page to avoid having to tab through the whole menu to get access to the main content

## Demo
Example on :https://design-system-git-main-skip-to-main-content-strapijs.vercel.app

## API


```jsx
<AppRoot>
    <SkipToContent>Skip to main content</SkipToContent>
    <HeavyMenuWith200Links />
    <Main labelledBy="main">
      <h1 id="main">This is a storybook story</h1>
    </Main>
</AppRoot>
```

## Voiceover

![Voiceover usage for the main content and SkipToContent](https://user-images.githubusercontent.com/3874873/117793000-1a187080-b24c-11eb-8151-90cd755a093c.gif)
