### PR TITLE
Use theme shadows instead of raw box-shadow

### DIFF
--- a/packages/strapi-design-system/src/Pagination/__tests__/Pagination.spec.js
+++ b/packages/strapi-design-system/src/Pagination/__tests__/Pagination.spec.js
@@ -96,7 +96,7 @@ describe('Pagination', () => {
       .c5 {
         padding: 12px;
         border-radius: 4px;
-        box-shadow: 0px 1px 4px rgba(26,26,67,0.1);
+        box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
         -webkit-text-decoration: none;
         text-decoration: none;
         display: -webkit-box;
@@ -111,7 +111,7 @@ describe('Pagination', () => {
       }
 
       .c6:hover {
-        box-shadow: 0px 1px 4px rgba(26,26,67,0.1);
+        box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
       }
 
       .c9 {
@@ -119,7 +119,7 @@ describe('Pagination', () => {
       }
 
       .c9:hover {
-        box-shadow: 0px 1px 4px rgba(26,26,67,0.1);
+        box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
       }
 
       .c3 {
@@ -375,7 +375,7 @@ describe('Pagination', () => {
       .c9 {
         padding: 12px;
         border-radius: 4px;
-        box-shadow: 0px 1px 4px rgba(26,26,67,0.1);
+        box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
         -webkit-text-decoration: none;
         text-decoration: none;
         display: -webkit-box;
@@ -389,7 +389,7 @@ describe('Pagination', () => {
       }
 
       .c5:hover {
-        box-shadow: 0px 1px 4px rgba(26,26,67,0.1);
+        box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
       }
 
       .c10 {
@@ -398,7 +398,7 @@ describe('Pagination', () => {
       }
 
       .c10:hover {
-        box-shadow: 0px 1px 4px rgba(26,26,67,0.1);
+        box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
       }
 
       .c3 {

--- a/packages/strapi-design-system/src/Pagination/components.js
+++ b/packages/strapi-design-system/src/Pagination/components.js
@@ -15,7 +15,7 @@ const LinkWrapper = styled.a`
   padding: ${({ theme }) => theme.spaces[3]};
   border-radius: ${({ theme }) => theme.borderRadius};
   // TODO: make sure to use the one from the theme
-  box-shadow: ${({ active }) => (active ? `0px 1px 4px rgba(26, 26, 67, 0.1)` : undefined)};
+  box-shadow: ${({ active, theme }) => (active ? theme.shadows.filterShadow : undefined)};
   text-decoration: none;
   display: flex;
 `;
@@ -25,7 +25,7 @@ const PageLinkWrapper = styled(LinkWrapper)`
   background: ${({ theme, active }) => (active ? theme.colors.neutral0 : undefined)};
 
   &:hover {
-    box-shadow: 0px 1px 4px rgba(26, 26, 67, 0.1);
+    box-shadow: ${({ theme }) => theme.shadows.filterShadow};
   }
 `;
 

--- a/packages/strapi-design-system/src/Pagination/components.js
+++ b/packages/strapi-design-system/src/Pagination/components.js
@@ -14,7 +14,6 @@ const PaginationText = styled(Text)`
 const LinkWrapper = styled.a`
   padding: ${({ theme }) => theme.spaces[3]};
   border-radius: ${({ theme }) => theme.borderRadius};
-  // TODO: make sure to use the one from the theme
   box-shadow: ${({ active, theme }) => (active ? theme.shadows.filterShadow : undefined)};
   text-decoration: none;
   display: flex;

--- a/packages/strapi-design-system/src/Popover/Popover.js
+++ b/packages/strapi-design-system/src/Popover/Popover.js
@@ -17,8 +17,7 @@ const position = (source) => {
 };
 
 const PopoverWrapper = styled(Box)`
-  // TODO: use the one in the theme when it's available
-  box-shadow: 0px 1px 4px rgba(33, 33, 52, 0.1);
+  box-shadow: ${({ theme }) => theme.shadows.filterShadow};
   display: ${({ visible }) => (visible ? 'block' : 'none')};
   position: absolute;
   border: 1px solid ${({ theme }) => theme.colors.neutral150};

--- a/packages/strapi-design-system/src/Searchbar/Searchbar.js
+++ b/packages/strapi-design-system/src/Searchbar/Searchbar.js
@@ -22,9 +22,8 @@ const SearchIconWrapper = styled(Row)`
 `;
 
 const SearchbarWrapper = styled.div`
-  // TODO: use the shadows from the theme when it's available
   border-radius: ${({ theme }) => theme.borderRadius};
-  box-shadow: 0px 1px 4px rgba(26, 26, 67, 0.1), inset 0px 0px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: ${({ theme }) => theme.shadows.filterShadow};
 
   &:focus-within {
     ${SearchIconWrapper} {

--- a/packages/strapi-design-system/src/Searchbar/__tests__/Searchbar.spec.js
+++ b/packages/strapi-design-system/src/Searchbar/__tests__/Searchbar.spec.js
@@ -176,7 +176,7 @@ describe('Searchbar', () => {
 
       .c0 {
         border-radius: 4px;
-        box-shadow: 0px 1px 4px rgba(26,26,67,0.1),inset 0px 0px 3px rgba(0,0,0,0.1);
+        box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
       }
 
       .c0:focus-within .c7 svg path {


### PR DESCRIPTION
# [title]

## Description
[add description]

## Demo
Example on : [deployed story link]

## API
[api details]

```jsx
<YourComponent />
```

## Voiceover

[voiceover gif]