### PR TITLE
Fixing vertical alignment in Alert

### DIFF
--- a/packages/strapi-design-system/src/Alert/Alert.js
+++ b/packages/strapi-design-system/src/Alert/Alert.js
@@ -53,10 +53,8 @@ const AlertIcon = ({ variant, ...props }) => {
 };
 
 const ActionBox = styled(Box)`
-  & a {
-    line-height: ${12 / 16}rem;
-    vertical-align: middle;
-  }
+  // Checked with the designers, validated
+  padding-top: 1px;
 
   & a > span {
     color: ${handleIconColor};

--- a/packages/strapi-design-system/src/Alert/Alert.js
+++ b/packages/strapi-design-system/src/Alert/Alert.js
@@ -55,6 +55,7 @@ const AlertIcon = ({ variant, ...props }) => {
 const ActionBox = styled(Box)`
   & a {
     line-height: ${12 / 16}rem;
+    vertical-align: middle;
   }
 
   & a > span {


### PR DESCRIPTION
<img width="627" alt="The alert component shown in storybook" src="https://user-images.githubusercontent.com/3874873/119447409-24e50200-bd30-11eb-9eb9-6ce2450595c4.png">

https://design-system-git-fix-link-alignment-strapijs.vercel.app/?path=/story/alert--base