### PR TITLE
Preparing generic input

### DIFF
--- a/.github/workflows/playwright-ci.yml
+++ b/.github/workflows/playwright-ci.yml
@@ -35,3 +35,6 @@ jobs:
 
       - name: Run the tests
         run: yarn test:e2e:ci
+
+      - name: Run tests of the example app
+        run: yarn setup:example && yarn test:example

--- a/example/src/ContentManager/EditViewPage.js
+++ b/example/src/ContentManager/EditViewPage.js
@@ -14,6 +14,7 @@ import { Information } from "./EditView/Information";
 import { Reviews } from "./EditView/Reviews";
 import { SideActions } from "./EditView/SideAction";
 import { AdminLayout } from "../layouts/AdminLayout";
+import { GenericInput } from "../shared/GenericInput/GenericInput";
 
 export const EditViewPage = () => {
   const [loading, setLoading] = useState(true);
@@ -36,6 +37,7 @@ export const EditViewPage = () => {
 
   return (
     <AdminLayout>
+      <GenericInput />
       <Box>
         <Stack size={2}>
           <Link to="/" leftIcon={<BackIcon />}>

--- a/example/src/shared/GenericInput/GenericInput.js
+++ b/example/src/shared/GenericInput/GenericInput.js
@@ -17,13 +17,13 @@ export const GenericInput = ({ type, label, name, onChange, ...props }) => {
 
   if (type === "checkbox") {
     return (
-      <Checkbox id="default" name={name} onValueChange={onChange}>
+      <Checkbox name={name} onValueChange={onChange} {...props}>
         {label}
       </Checkbox>
     );
   }
 
-  return <div>hello world</div>;
+  return null;
 };
 
 GenericInput.propTypes = {

--- a/example/src/shared/GenericInput/GenericInput.js
+++ b/example/src/shared/GenericInput/GenericInput.js
@@ -1,6 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { TextInput, Checkbox, RadioGroup, Radio } from "@strapi/design-system";
+import {
+  TextInput,
+  Checkbox,
+  RadioGroup,
+  Radio,
+  Textarea,
+} from "@strapi/design-system";
 
 export const GenericInput = ({
   type,
@@ -46,6 +52,20 @@ export const GenericInput = ({
     );
   }
 
+  if (type === "textarea") {
+    const { value, ...regularProps } = props;
+    return (
+      <Textarea
+        label={label}
+        name={name}
+        onChange={(e) => onChange(e.target.value)}
+        {...regularProps}
+      >
+        {value}
+      </Textarea>
+    );
+  }
+
   return null;
 };
 
@@ -55,7 +75,7 @@ GenericInput.defaultProps = {
 };
 
 GenericInput.propTypes = {
-  type: PropTypes.oneOf(["text", "checkbox", "radio"]).isRequired,
+  type: PropTypes.oneOf(["text", "checkbox", "radio", "textarea"]).isRequired,
   label: PropTypes.string,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,

--- a/example/src/shared/GenericInput/GenericInput.js
+++ b/example/src/shared/GenericInput/GenericInput.js
@@ -1,8 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { TextInput, Checkbox } from "@strapi/design-system";
+import { TextInput, Checkbox, RadioGroup, Radio } from "@strapi/design-system";
 
-export const GenericInput = ({ type, label, name, onChange, ...props }) => {
+export const GenericInput = ({
+  type,
+  label,
+  name,
+  onChange,
+  options,
+  ...props
+}) => {
   if (type === "text") {
     return (
       <TextInput
@@ -23,12 +30,39 @@ export const GenericInput = ({ type, label, name, onChange, ...props }) => {
     );
   }
 
+  if (type === "radio") {
+    return (
+      <RadioGroup
+        onChange={(e) => onChange(e.target.value)}
+        name={name}
+        {...props}
+      >
+        {options.map((option) => (
+          <Radio value={option.value} key={option.value}>
+            {option.label}
+          </Radio>
+        ))}
+      </RadioGroup>
+    );
+  }
+
   return null;
 };
 
+GenericInput.defaultProps = {
+  label: undefined,
+  options: [],
+};
+
 GenericInput.propTypes = {
-  type: PropTypes.oneOf(["text", "checkbox"]).isRequired,
-  label: PropTypes.string.isRequired,
+  type: PropTypes.oneOf(["text", "checkbox", "radio"]).isRequired,
+  label: PropTypes.string,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    })
+  ),
 };

--- a/example/src/shared/GenericInput/GenericInput.js
+++ b/example/src/shared/GenericInput/GenericInput.js
@@ -1,0 +1,34 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { TextInput, Checkbox } from "@strapi/design-system";
+
+export const GenericInput = ({ type, label, name, onChange, ...props }) => {
+  if (type === "text") {
+    return (
+      <TextInput
+        type={type}
+        name={name}
+        label={label}
+        onChange={(e) => onChange(e.target.value)}
+        {...props}
+      />
+    );
+  }
+
+  if (type === "checkbox") {
+    return (
+      <Checkbox id="default" name={name} onValueChange={onChange}>
+        {label}
+      </Checkbox>
+    );
+  }
+
+  return <div>hello world</div>;
+};
+
+GenericInput.propTypes = {
+  type: PropTypes.oneOf(["text", "checkbox"]).isRequired,
+  label: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+};

--- a/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
+++ b/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
@@ -164,4 +164,87 @@ describe("GenericInput", () => {
       expect(onChangeSpy).toBeCalledWith(true);
     });
   });
+
+  describe("radio", () => {
+    it("renders a radio for type radio", () => {
+      const { container } = render(
+        <ThemeProvider theme={lightTheme}>
+          <GenericInput
+            type="radio"
+            name="favorite-plate"
+            onChange={() => {}}
+            options={[
+              { label: "Pizza", value: "pizza" },
+              { label: "Bagel", value: "bagel" },
+            ]}
+          />
+        </ThemeProvider>
+      );
+
+      expect(container.firstChild).toMatchInlineSnapshot(`
+        <div
+          role="radiogroup"
+        >
+          <label
+            class="sc-eCApnc sc-jcwpoC imgJpN jaONGg"
+          >
+            <input
+              aria-checked="false"
+              class="sc-hBMUJo kaPkmY"
+              name="favorite-plate"
+              tabindex="0"
+              type="radio"
+              value="pizza"
+            />
+            <div
+              class="sc-bdnxRM cpgqnJ"
+            >
+              Pizza
+            </div>
+          </label>
+          <label
+            class="sc-eCApnc sc-jcwpoC imgJpN jaONGg"
+          >
+            <input
+              aria-checked="false"
+              class="sc-hBMUJo kaPkmY"
+              name="favorite-plate"
+              tabindex="-1"
+              type="radio"
+              value="bagel"
+            />
+            <div
+              class="sc-bdnxRM cpgqnJ"
+            >
+              Bagel
+            </div>
+          </label>
+        </div>
+      `);
+    });
+
+    it("retrieves a boolean value when calling onChange", () => {
+      const onChangeSpy = jest.fn();
+
+      render(
+        <ThemeProvider theme={lightTheme}>
+          <GenericInput
+            type="radio"
+            name="favorite-plate"
+            onChange={onChangeSpy}
+            options={[
+              { label: "Pizza", value: "pizza" },
+              { label: "Bagel", value: "bagel" },
+            ]}
+          />
+        </ThemeProvider>
+      );
+
+      const bagel = screen.getByLabelText("Bagel");
+
+      fireEvent.click(bagel);
+
+      expect(onChangeSpy).toBeCalledWith("bagel");
+    });
+  });
 });

--- a/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
+++ b/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
@@ -247,4 +247,75 @@ describe("GenericInput", () => {
       expect(onChangeSpy).toBeCalledWith("bagel");
     });
   });
+
+  describe("textarea", () => {
+    it("renders an input for type text", () => {
+      const { container } = render(
+        <ThemeProvider theme={lightTheme}>
+          <GenericInput
+            type="textarea"
+            name="long-content"
+            id="some-id"
+            label="Hello world"
+            onChange={() => {}}
+          />
+        </ThemeProvider>
+      );
+
+      expect(container.firstChild).toMatchInlineSnapshot(`
+        <div
+          class="sc-khIgEk fvOCv"
+        >
+          <div>
+            <div
+              class="sc-efHYUO cwLEVt"
+            >
+              <div
+                class="sc-fujyAs iDPWRy"
+              >
+                <label
+                  class="sc-eCApnc XCYtb"
+                  for="field-some-id"
+                >
+                  Hello world
+                </label>
+              </div>
+              <div
+                class="sc-fujyAs sc-dIvrsQ hbgaeN bldbdh"
+              >
+                <textarea
+                  aria-invalid="false"
+                  class="sc-iemWCZ cIJrJM"
+                  id="field-some-id"
+                  name="long-content"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      `);
+    });
+
+    it("retrieves a string on change", async () => {
+      const onChangeSpy = jest.fn();
+
+      render(
+        <ThemeProvider theme={lightTheme}>
+          <GenericInput
+            type="textarea"
+            name="long-content"
+            id="some-id"
+            label="Hello world"
+            onChange={onChangeSpy}
+          />
+        </ThemeProvider>
+      );
+
+      const input = await waitFor(() => screen.getByLabelText("Hello world"));
+
+      fireEvent.change(input, { target: { value: "hello moto" } });
+
+      expect(onChangeSpy).toBeCalledWith("hello moto");
+    });
+  });
 });

--- a/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
+++ b/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
@@ -8,6 +8,34 @@ jest.mock("uuid", () => ({
 }));
 
 describe("GenericInput", () => {
+  describe("unmatched type", () => {
+    let rawConsoleError;
+
+    beforeEach(() => {
+      // Hides the error message thrown by PropTypes preventing the test from giving an error in the logs
+      rawConsoleError = console.error;
+      console.error = () => undefined;
+    });
+
+    afterEach(() => {
+      console.error = rawConsoleError;
+    });
+
+    it("returns nothing when the type does not match any predicted ones", () => {
+      const { container } = render(
+        <ThemeProvider theme={lightTheme}>
+          <GenericInput
+            type="not existing type"
+            name="some text"
+            label="Hello world"
+          />
+        </ThemeProvider>
+      );
+
+      expect(container.firstChild).toBe(null);
+    });
+  });
+
   describe("text", () => {
     it("renders an input for type text", () => {
       const { container } = render(
@@ -95,22 +123,22 @@ describe("GenericInput", () => {
       );
 
       expect(container.firstChild).toMatchInlineSnapshot(`
-          <label
-            class="sc-eCApnc sc-fFSPTT imgJpN bwVixM"
+        <label
+          class="sc-eCApnc sc-fFSPTT imgJpN bwVixM"
+        >
+          <input
+            class="sc-ksluID bLZHCe"
+            id="some-id"
+            name="some text"
+            type="checkbox"
+          />
+          <div
+            class="sc-bdnxRM cpgqnJ"
           >
-            <input
-              class="sc-ksluID bLZHCe"
-              id="default"
-              name="some text"
-              type="checkbox"
-            />
-            <div
-              class="sc-bdnxRM cpgqnJ"
-            >
-              Hello world
-            </div>
-          </label>
-        `);
+            Hello world
+          </div>
+        </label>
+      `);
     });
 
     it("retrieves a boolean value when calling onChange", () => {

--- a/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
+++ b/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
@@ -3,10 +3,6 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { GenericInput } from "../GenericInput";
 import { ThemeProvider, lightTheme } from "@strapi/design-system";
 
-jest.mock("uuid", () => ({
-  v4: () => 1,
-}));
-
 describe("GenericInput", () => {
   describe("unmatched type", () => {
     let rawConsoleError;

--- a/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
+++ b/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
@@ -1,0 +1,117 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { GenericInput } from "../GenericInput";
+import { ThemeProvider, lightTheme } from "@strapi/design-system";
+
+jest.mock("uuid", () => ({
+  v4: () => 1,
+}));
+
+describe("GenericInput", () => {
+  describe("text", () => {
+    it("renders an input for type text", () => {
+      const { container } = render(
+        <ThemeProvider theme={lightTheme}>
+          <GenericInput
+            type="text"
+            name="some text"
+            id="some-id"
+            label="Hello world"
+            onChange={() => {}}
+          />
+        </ThemeProvider>
+      );
+
+      expect(container.firstChild).toMatchInlineSnapshot(`
+        <div
+          class="sc-Arkif cqHgOr"
+        >
+          <div>
+            <div
+              class="sc-efHYUO cwLEVt"
+            >
+              <div
+                class="sc-fujyAs iDPWRy"
+              >
+                <label
+                  class="sc-eCApnc XCYtb"
+                  for="field-some-id"
+                >
+                  Hello world
+                </label>
+              </div>
+              <div
+                class="sc-fujyAs sc-dIvrsQ hbgaeN bldbdh"
+              >
+                <input
+                  aria-invalid="false"
+                  class="sc-iemWCZ cIJrJM"
+                  id="some-id"
+                  name="some text"
+                  type="text"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      `);
+    });
+  });
+
+  describe("checkbox", () => {
+    it("renders a checkbox for type checkbox", () => {
+      const { container } = render(
+        <ThemeProvider theme={lightTheme}>
+          <GenericInput
+            type="checkbox"
+            name="some text"
+            id="some-id"
+            label="Hello world"
+            onChange={() => {}}
+          />
+        </ThemeProvider>
+      );
+
+      expect(container.firstChild).toMatchInlineSnapshot(`
+          <label
+            class="sc-eCApnc sc-fFSPTT imgJpN bwVixM"
+          >
+            <input
+              class="sc-ksluID bLZHCe"
+              id="default"
+              name="some text"
+              type="checkbox"
+            />
+            <div
+              class="sc-bdnxRM cpgqnJ"
+            >
+              Hello world
+            </div>
+          </label>
+        `);
+    });
+
+    it("retrieves a boolean value when calling onChange", () => {
+      const onChangSpy = jest.fn();
+
+      render(
+        <ThemeProvider theme={lightTheme}>
+          <GenericInput
+            type="checkbox"
+            name="some text"
+            id="some-id"
+            label="Hello world"
+            onChange={onChangSpy}
+            value={false}
+          />
+        </ThemeProvider>
+      );
+
+      const input = screen.getByLabelText("Hello world");
+
+      fireEvent.click(input);
+
+      expect(onChangSpy).toBeCalledWith(true);
+    });
+  });
+});

--- a/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
+++ b/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { GenericInput } from "../GenericInput";
 import { ThemeProvider, lightTheme } from "@strapi/design-system";
 
@@ -46,7 +46,7 @@ describe("GenericInput", () => {
                 <input
                   aria-invalid="false"
                   class="sc-iemWCZ cIJrJM"
-                  id="some-id"
+                  id="field-some-id"
                   name="some text"
                   type="text"
                 />
@@ -55,6 +55,28 @@ describe("GenericInput", () => {
           </div>
         </div>
       `);
+    });
+
+    it("retrieves a string on change", async () => {
+      const onChangeSpy = jest.fn();
+
+      render(
+        <ThemeProvider theme={lightTheme}>
+          <GenericInput
+            type="text"
+            name="some text"
+            id="some-id"
+            label="Hello world"
+            onChange={onChangeSpy}
+          />
+        </ThemeProvider>
+      );
+
+      const input = await waitFor(() => screen.getByLabelText("Hello world"));
+
+      fireEvent.change(input, { target: { value: "hello moto" } });
+
+      expect(onChangeSpy).toBeCalledWith("hello moto");
     });
   });
 
@@ -92,7 +114,7 @@ describe("GenericInput", () => {
     });
 
     it("retrieves a boolean value when calling onChange", () => {
-      const onChangSpy = jest.fn();
+      const onChangeSpy = jest.fn();
 
       render(
         <ThemeProvider theme={lightTheme}>
@@ -101,7 +123,7 @@ describe("GenericInput", () => {
             name="some text"
             id="some-id"
             label="Hello world"
-            onChange={onChangSpy}
+            onChange={onChangeSpy}
             value={false}
           />
         </ThemeProvider>
@@ -111,7 +133,7 @@ describe("GenericInput", () => {
 
       fireEvent.click(input);
 
-      expect(onChangSpy).toBeCalledWith(true);
+      expect(onChangeSpy).toBeCalledWith(true);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
     "lint-staged": "lerna run lint-staged --stream --",
     "lint": "lerna run lint --stream",
     "setup": "yarn && yarn bootstrap && yarn build",
+    "setup:example": "yarn --cwd example",
     "specify:pull": "specify pull",
     "specify:sync": "specify sync",
     "start:example": "yarn --cwd ./packages/cra-example start",
     "storybook": "lerna run storybook --stream",
+    "test:example": "yarn --cwd example test --watchAll=false",
     "test:e2e:ci": "lerna run test:e2e:ci",
     "test:e2e": "lerna run test:e2e --stream",
     "test": "lerna run test --stream"

--- a/packages/strapi-design-system/src/Field/Field.js
+++ b/packages/strapi-design-system/src/Field/Field.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { genId } from '../helpers/genId';
 import { FieldContext } from './FieldContext';
 
-export const Field = ({ children, name, error, hint }) => {
-  const idRef = useRef(genId());
+export const Field = ({ children, name, error, hint, id }) => {
+  const idRef = useRef(id || genId());
 
   return (
     <div>
@@ -16,11 +16,13 @@ export const Field = ({ children, name, error, hint }) => {
 Field.defaultProps = {
   error: undefined,
   hint: undefined,
+  id: undefined,
 };
 
 Field.propTypes = {
   children: PropTypes.node.isRequired,
   error: PropTypes.string,
   hint: PropTypes.string,
+  id: PropTypes.string,
   name: PropTypes.string.isRequired,
 };

--- a/packages/strapi-design-system/src/TextInput/TextInput.js
+++ b/packages/strapi-design-system/src/TextInput/TextInput.js
@@ -13,10 +13,10 @@ const TextInputWrapper = styled.div`
 `;
 
 export const TextInput = React.forwardRef(
-  ({ leftAction, rightAction, name, hint, error, label, labelAction, ...props }, ref) => {
+  ({ leftAction, rightAction, name, hint, error, label, labelAction, id, ...props }, ref) => {
     return (
       <TextInputWrapper>
-        <Field name={name} hint={hint} error={error}>
+        <Field name={name} hint={hint} error={error} id={id}>
           <Stack size={1}>
             <Row cols="auto auto 1fr" gap={1}>
               <FieldLabel>{label}</FieldLabel>
@@ -38,6 +38,7 @@ TextInput.defaultProps = {
   labelAction: undefined,
   error: undefined,
   hint: undefined,
+  id: undefined,
   leftAction: undefined,
   rightAction: undefined,
 };
@@ -45,6 +46,7 @@ TextInput.defaultProps = {
 TextInput.propTypes = {
   error: PropTypes.string,
   hint: PropTypes.string,
+  id: PropTypes.string,
   label: PropTypes.string.isRequired,
   labelAction: PropTypes.element,
   leftAction: PropTypes.element,

--- a/packages/strapi-design-system/src/Textarea/Textarea.js
+++ b/packages/strapi-design-system/src/Textarea/Textarea.js
@@ -13,10 +13,10 @@ const TextareaWrapper = styled.div`
 `;
 
 export const Textarea = React.forwardRef(
-  ({ leftAction, rightAction, name, hint, error, label, children, labelAction, ...props }, ref) => {
+  ({ leftAction, rightAction, name, hint, error, label, children, labelAction, id, ...props }, ref) => {
     return (
       <TextareaWrapper>
-        <Field name={name} hint={hint} error={error}>
+        <Field name={name} hint={hint} error={error} id={id}>
           <Stack size={1}>
             <Row cols="auto auto 1fr" gap={1}>
               <FieldLabel>{label}</FieldLabel>
@@ -45,6 +45,7 @@ Textarea.defaultProps = {
   labelAction: undefined,
   error: undefined,
   hint: undefined,
+  id: undefined,
   leftAction: undefined,
   rightAction: undefined,
   children: '',
@@ -54,6 +55,7 @@ Textarea.propTypes = {
   children: PropTypes.string,
   error: PropTypes.string,
   hint: PropTypes.string,
+  id: PropTypes.string,
   label: PropTypes.string.isRequired,
   labelAction: PropTypes.element,
   leftAction: PropTypes.element,


### PR DESCRIPTION
# Preparing generic input

## Description

This idea is to prepare the GenericInput component that @soupette is waiting for so long. It aims to be experimental and outside the @strapi/design-system package (it's in the cra-example for now) until we find a good place to put it.

## Demo
Example on : [deployed story link]

## API



```jsx
GenericInput.propTypes = {
  type: PropTypes.oneOf(["text", "checkbox", "radio", "textarea"]).isRequired,
  label: PropTypes.string,
  name: PropTypes.string.isRequired,
  onChange: PropTypes.func.isRequired,
  options: PropTypes.arrayOf(
    PropTypes.shape({
      value: PropTypes.string.isRequired,
      label: PropTypes.string.isRequired,
    })
  ),
};
```