### PR TITLE
Date picker (first iteration)

### DIFF
--- a/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
+++ b/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
@@ -48,14 +48,14 @@ describe("GenericInput", () => {
 
       expect(container.firstChild).toMatchInlineSnapshot(`
         <div
-          class="sc-Arkif cqHgOr"
+          class="sc-hhIiOg cXALHk"
         >
           <div>
             <div
-              class="sc-efHYUO cwLEVt"
+              class="sc-iklJeh gJvfyo"
             >
               <div
-                class="sc-fujyAs iDPWRy"
+                class="sc-fujyAs ezPyIe"
               >
                 <label
                   class="sc-eCApnc XCYtb"
@@ -65,11 +65,11 @@ describe("GenericInput", () => {
                 </label>
               </div>
               <div
-                class="sc-fujyAs sc-dIvrsQ hbgaeN bldbdh"
+                class="sc-fujyAs sc-dIvrsQ iotgDl bldbdh"
               >
                 <input
                   aria-invalid="false"
-                  class="sc-iemWCZ cIJrJM"
+                  class="sc-iemWCZ LWKNf"
                   id="field-some-id"
                   name="some text"
                   type="text"
@@ -182,7 +182,7 @@ describe("GenericInput", () => {
           role="radiogroup"
         >
           <label
-            class="sc-eCApnc sc-jcwpoC imgJpN jaONGg"
+            class="sc-eCApnc sc-bBjRSN imgJpN jdzIYP"
           >
             <input
               aria-checked="false"
@@ -199,7 +199,7 @@ describe("GenericInput", () => {
             </div>
           </label>
           <label
-            class="sc-eCApnc sc-jcwpoC imgJpN jaONGg"
+            class="sc-eCApnc sc-bBjRSN imgJpN jdzIYP"
           >
             <input
               aria-checked="false"
@@ -260,14 +260,14 @@ describe("GenericInput", () => {
 
       expect(container.firstChild).toMatchInlineSnapshot(`
         <div
-          class="sc-khIgEk fvOCv"
+          class="sc-lbVvki bwfhsz"
         >
           <div>
             <div
-              class="sc-efHYUO cwLEVt"
+              class="sc-iklJeh gJvfyo"
             >
               <div
-                class="sc-fujyAs iDPWRy"
+                class="sc-fujyAs ezPyIe"
               >
                 <label
                   class="sc-eCApnc XCYtb"
@@ -276,16 +276,12 @@ describe("GenericInput", () => {
                   Hello world
                 </label>
               </div>
-              <div
-                class="sc-fujyAs sc-dIvrsQ hbgaeN bldbdh"
-              >
-                <textarea
-                  aria-invalid="false"
-                  class="sc-iemWCZ cIJrJM"
-                  id="field-some-id"
-                  name="long-content"
-                />
-              </div>
+              <textarea
+                aria-invalid="false"
+                class="sc-eirqVv ixVjcw"
+                id="field-some-id"
+                name="long-content"
+              />
             </div>
           </div>
         </div>

--- a/packages/strapi-design-system/src/Avatar/Avatar.stories.mdx
+++ b/packages/strapi-design-system/src/Avatar/Avatar.stories.mdx
@@ -3,16 +3,7 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import { Avatar } from './Avatar';
 
-<Meta
-  title="Avatar"
-  component={Avatar}
-  parameters={{
-    design: {
-      type: 'figma',
-      url: 'TODO: Fill the according figma file',
-    },
-  }}
-/>
+<Meta title="Avatar" component={Avatar} />
 
 # Avatar
 

--- a/packages/strapi-design-system/src/Avatar/Avatar.stories.mdx
+++ b/packages/strapi-design-system/src/Avatar/Avatar.stories.mdx
@@ -1,13 +1,11 @@
 <!--- Avatar.stories.mdx --->
 
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
-import { withDesign } from 'storybook-addon-designs';
 import { Avatar } from './Avatar';
 
 <Meta
   title="Avatar"
   component={Avatar}
-  decorators={[withDesign]}
   parameters={{
     design: {
       type: 'figma',

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.js
@@ -57,10 +57,9 @@ export const DatePicker = ({ initialDate, selectedDate, onChange, label, selecte
         {...props}
       />
 
-      {inputRef && inputRef.current && inputRef.current.inputWrapperRef && visible && (
+      {inputRef.current && inputRef.current.inputWrapperRef && visible && (
         <Popover
           source={inputRef.current.inputWrapperRef}
-          visible={visible}
           role="dialog"
           aria-modal="true"
           aria-label={label}

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.js
@@ -10,6 +10,7 @@ import { generateWeeks } from './generateWeeks';
 import { FocusTrap } from '../FocusTrap';
 import { TextInput } from '../TextInput';
 import { VisuallyHidden } from '../VisuallyHidden';
+import { getDayOfWeek } from './getDayOfWeek';
 
 const DatePickerButton = styled.button`
   border: none;
@@ -22,9 +23,9 @@ export const DatePicker = ({ initialDate, selectedDate, onChange, label, selecte
   const inputRef = useRef(null);
 
   const [weeks, activeRow, activeCol] = generateWeeks(initialDate, selectedDate);
+  const { sun, mon, tue, wed, thu, fri, sat } = getDayOfWeek();
 
   const langFormatter = new Intl.DateTimeFormat();
-
   const formattedDate = selectedDate ? langFormatter.format(selectedDate) : '';
   const placeholder = langFormatter.format(new Date(1970, 0, 1));
 
@@ -70,13 +71,13 @@ export const DatePicker = ({ initialDate, selectedDate, onChange, label, selecte
               <Table colCount={7} rowCount={weeks.length + 1} initialCol={activeCol} initialRow={activeRow} role="grid">
                 <Thead>
                   <Tr>
-                    <DatePickerTh>Sunday</DatePickerTh>
-                    <DatePickerTh>Monday</DatePickerTh>
-                    <DatePickerTh>Tuesday</DatePickerTh>
-                    <DatePickerTh>Wednesday</DatePickerTh>
-                    <DatePickerTh>Thursday</DatePickerTh>
-                    <DatePickerTh>Friday</DatePickerTh>
-                    <DatePickerTh>Saturday</DatePickerTh>
+                    <DatePickerTh>{sun}</DatePickerTh>
+                    <DatePickerTh>{mon}</DatePickerTh>
+                    <DatePickerTh>{tue}</DatePickerTh>
+                    <DatePickerTh>{wed}</DatePickerTh>
+                    <DatePickerTh>{thu}</DatePickerTh>
+                    <DatePickerTh>{fri}</DatePickerTh>
+                    <DatePickerTh>{sat}</DatePickerTh>
                   </Tr>
                 </Thead>
                 <Tbody>

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.js
@@ -33,18 +33,20 @@ export const DatePicker = ({ initialDate, selectedDate, onChange, label, selecte
     setVisible(false);
   };
 
+  const toggleVisibility = () => setVisible((prevVisible) => !prevVisible);
+
   return (
     <div>
       <TextInput
         ref={inputRef}
-        onClick={() => setVisible((s) => !s)}
+        onClick={toggleVisibility}
         // Prevent input from changing for now
         onChange={() => {}}
         value={formattedDate}
         placeholder={placeholder}
         leftAction={
           <DatePickerButton
-            onClick={() => setVisible((s) => !s)}
+            onClick={toggleVisibility}
             aria-label={selectedDate ? selectedDateLabel(langFormatter.format(selectedDate)) : label}
           >
             <CalendarIcon aria-hidden={true} />
@@ -55,7 +57,7 @@ export const DatePicker = ({ initialDate, selectedDate, onChange, label, selecte
         {...props}
       />
 
-      {inputRef && inputRef.current && inputRef.current.inputWrapperRef && (
+      {inputRef && inputRef.current && inputRef.current.inputWrapperRef && visible && (
         <Popover
           source={inputRef.current.inputWrapperRef}
           visible={visible}

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.js
@@ -1,0 +1,124 @@
+import React, { useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import CalendarIcon from '@strapi/icons/Calendar';
+import styled from 'styled-components';
+import { Popover } from '../Popover';
+import { Table, Thead, Tbody, Tr } from '../Table';
+import { DatePickerTh } from './DatePickerTh';
+import { DatePickerTd } from './DatePickerTd';
+import { generateWeeks } from './generateWeeks';
+import { FocusTrap } from '../FocusTrap';
+import { TextInput } from '../TextInput';
+import { VisuallyHidden } from '../VisuallyHidden';
+
+const DatePickerButton = styled.button`
+  border: none;
+  background: transparent;
+  border-radius: ${({ theme }) => theme.borderRadius};
+`;
+
+export const DatePicker = ({ initialDate, selectedDate, onChange, label, selectedDateLabel, ...props }) => {
+  const [visible, setVisible] = useState(false);
+  const inputRef = useRef(null);
+
+  const [weeks, activeRow, activeCol] = generateWeeks(initialDate, selectedDate);
+
+  const langFormatter = new Intl.DateTimeFormat();
+
+  const formattedDate = selectedDate ? langFormatter.format(selectedDate) : '';
+  const placeholder = langFormatter.format(new Date(1970, 0, 1));
+
+  const handleSelectDay = (date) => {
+    onChange(date);
+    setVisible(false);
+  };
+
+  return (
+    <div>
+      <TextInput
+        ref={inputRef}
+        onClick={() => setVisible((s) => !s)}
+        // Prevent input from changing for now
+        onChange={() => {}}
+        value={formattedDate}
+        placeholder={placeholder}
+        leftAction={
+          <DatePickerButton
+            onClick={() => setVisible((s) => !s)}
+            aria-label={selectedDate ? selectedDateLabel(langFormatter.format(selectedDate)) : label}
+          >
+            <CalendarIcon aria-hidden={true} />
+          </DatePickerButton>
+        }
+        aria-autocomplete="none"
+        label={label}
+        {...props}
+      />
+
+      {inputRef && inputRef.current && inputRef.current.inputWrapperRef && (
+        <Popover
+          source={inputRef.current.inputWrapperRef}
+          visible={visible}
+          role="dialog"
+          aria-modal="true"
+          aria-label={label}
+          spacingTop={2}
+        >
+          {visible && (
+            <FocusTrap onEscape={() => setVisible(false)}>
+              <Table colCount={7} rowCount={weeks.length + 1} initialCol={activeCol} initialRow={activeRow} role="grid">
+                <Thead>
+                  <Tr>
+                    <DatePickerTh>Sunday</DatePickerTh>
+                    <DatePickerTh>Monday</DatePickerTh>
+                    <DatePickerTh>Tuesday</DatePickerTh>
+                    <DatePickerTh>Wednesday</DatePickerTh>
+                    <DatePickerTh>Thursday</DatePickerTh>
+                    <DatePickerTh>Friday</DatePickerTh>
+                    <DatePickerTh>Saturday</DatePickerTh>
+                  </Tr>
+                </Thead>
+                <Tbody>
+                  {weeks.map((week, index) => (
+                    <Tr key={`week-${index}`}>
+                      {week.map(({ date, outsideMonth, isSelected }) => {
+                        return (
+                          <DatePickerTd
+                            key={`${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`}
+                            outsideMonth={outsideMonth}
+                            onSelectDay={() => handleSelectDay(date)}
+                            isSelected={isSelected}
+                          >
+                            <span aria-hidden={true}>{date.getDate()}</span>
+                            <VisuallyHidden>
+                              <span>{langFormatter.format(date)}</span>
+                            </VisuallyHidden>
+                          </DatePickerTd>
+                        );
+                      })}
+                    </Tr>
+                  ))}
+                </Tbody>
+              </Table>
+            </FocusTrap>
+          )}
+        </Popover>
+      )}
+    </div>
+  );
+};
+
+DatePicker.displayName = DatePicker;
+
+DatePicker.defaultProps = {
+  initialDate: new Date(),
+  selectedDate: undefined,
+};
+
+DatePicker.propTypes = {
+  initialDate: PropTypes.instanceOf(Date),
+  label: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  selectedDate: PropTypes.instanceOf(Date),
+  selectedDateLabel: PropTypes.func.isRequired,
+};

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.stories.mdx
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.stories.mdx
@@ -1,0 +1,43 @@
+<!--- DatePicker.stories.mdx --->
+
+import { useState } from 'react';
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { withDesign } from 'storybook-addon-designs';
+import { DatePicker } from './DatePicker';
+
+<Meta
+  title="DatePicker"
+  component={DatePicker}
+  decorators={[withDesign]}
+  parameters={{
+    design: {
+      type: 'figma',
+      url: 'TODO: Fill the according figma file',
+    },
+  }}
+/>
+
+# DatePicker
+
+This is the doc of the `DatePicker` component
+
+## DatePicker
+
+Description...
+
+<Canvas>
+  <Story name="base">
+    {() => {
+      const [date, setDate] = useState();
+      return (
+        <DatePicker
+          onChange={setDate}
+          selectedDate={date}
+          label="Date picker"
+          name="datepicker"
+          selectedDateLabel={(formattedDate) => `Date picker, current is ${formattedDate}`}
+        />
+      );
+    }}
+  </Story>
+</Canvas>

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.stories.mdx
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.stories.mdx
@@ -2,13 +2,11 @@
 
 import { useState } from 'react';
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
-import { withDesign } from 'storybook-addon-designs';
 import { DatePicker } from './DatePicker';
 
 <Meta
   title="DatePicker"
   component={DatePicker}
-  decorators={[withDesign]}
   parameters={{
     design: {
       type: 'figma',

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.stories.mdx
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.stories.mdx
@@ -4,16 +4,7 @@ import { useState } from 'react';
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import { DatePicker } from './DatePicker';
 
-<Meta
-  title="DatePicker"
-  component={DatePicker}
-  parameters={{
-    design: {
-      type: 'figma',
-      url: 'TODO: Fill the according figma file',
-    },
-  }}
-/>
+<Meta title="DatePicker" component={DatePicker} />
 
 # DatePicker
 

--- a/packages/strapi-design-system/src/DatePicker/DatePickerTd.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePickerTd.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Td } from '../Table';
+import { Text } from '../Text';
+
+const DatePickerCellButton = styled.button`
+  border: none;
+  background: ${({ theme, isSelected }) => (isSelected ? theme.colors.primary100 : theme.colors.neutral0)};
+  height: ${32 / 16}rem;
+  text-align: center;
+  width: ${32 / 16}rem;
+  border-radius: ${({ theme }) => theme.borderRadius};
+
+  // Trick to prevent the outline from overflowing because of the general outline-offset
+  outline-offset: -2px;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.primary100};
+  }
+
+  &:hover > ${Text} {
+    color: ${({ theme }) => theme.colors.primary600};
+  }
+`;
+
+export const DatePickerTd = ({ children, outsideMonth, onSelectDay, isSelected, ...props }) => {
+  const textColor = isSelected ? 'primary600' : outsideMonth ? 'neutral600' : 'neutral800';
+
+  return (
+    <Td {...props}>
+      <DatePickerCellButton tabIndex={-1} onClick={onSelectDay} isSelected={isSelected}>
+        <Text small textColor={textColor} as="span">
+          {children}
+        </Text>
+      </DatePickerCellButton>
+    </Td>
+  );
+};
+
+DatePickerTd.defaultProps = {
+  isSelected: false,
+  outsideMonth: false,
+};
+
+DatePickerTd.propTypes = {
+  children: PropTypes.node.isRequired,
+  isSelected: PropTypes.bool,
+  onSelectDay: PropTypes.func.isRequired,
+  outsideMonth: PropTypes.bool,
+};

--- a/packages/strapi-design-system/src/DatePicker/DatePickerTh.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePickerTh.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Th } from '../Table';
+import { Text } from '../Text';
+import { VisuallyHidden } from '../VisuallyHidden';
+import { Row } from '../Row';
+
+const DatePickerThWrapper = styled(Th)`
+  // Trick to prevent the outline from overflowing because of the general outline-offset
+  outline-offset: -2px;
+  border-radius: ${({ theme }) => theme.borderRadius};
+`;
+
+const DatePickerThRow = styled(Row)`
+  height: ${24 / 16}rem;
+  width: ${32 / 16}rem;
+`;
+
+export const DatePickerTh = ({ children, ...props }) => {
+  return (
+    <DatePickerThWrapper {...props}>
+      <DatePickerThRow justifyContent="center">
+        <Text small highlighted={true} color="neutral800" aria-hidden as="span">
+          {children.substr(0, 2)}
+        </Text>
+
+        <VisuallyHidden>
+          <span>{children}</span>
+        </VisuallyHidden>
+      </DatePickerThRow>
+    </DatePickerThWrapper>
+  );
+};
+
+DatePickerTh.propTypes = {
+  children: PropTypes.string.isRequired,
+};

--- a/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.e2e.js
+++ b/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.e2e.js
@@ -1,0 +1,18 @@
+import { injectAxe, checkA11y } from 'axe-playwright';
+
+describe('DatePicker', () => {
+  beforeEach(async () => {
+    // This is the URL of the Storybook Iframe
+    await page.goto('http://localhost:6006/iframe.html?id=datepicker--base&viewMode=story');
+    await injectAxe(page);
+  });
+
+  it('triggers axe on the document', async () => {
+    await checkA11y(page);
+  });
+
+  it('triggers axe on the document with the dropdown open', async () => {
+    await page.click('input');
+    await checkA11y(page);
+  });
+});

--- a/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.spec.js
+++ b/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.spec.js
@@ -1,0 +1,212 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { DatePicker } from '../DatePicker';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+
+describe('DatePicker', () => {
+  const defaultIntlFormat = window.Intl.DateTimeFormat;
+
+  beforeEach(() => {
+    window.Intl.DateTimeFormat = () => ({
+      format: () => 1,
+    });
+  });
+
+  afterEach(() => {
+    window.Intl.DateTimeFormat = defaultIntlFormat;
+  });
+
+  it('snapshots the component', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <DatePicker
+          onChange={() => {}}
+          selectedDate={new Date(1, 0, 2021)}
+          label="Date picker"
+          name="datepicker"
+          selectedDateLabel={(formattedDate) => `Date picker, current is ${formattedDate}`}
+          id="date-picker"
+        />
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c6 {
+        padding-right: 8px;
+        padding-left: 12px;
+      }
+
+      .c3 {
+        font-weight: 500;
+        font-size: 0.75rem;
+        line-height: 1.33;
+        color: #32324d;
+      }
+
+      .c2 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+      }
+
+      .c4 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-box-pack: justify;
+        -webkit-justify-content: space-between;
+        -ms-flex-pack: justify;
+        justify-content: space-between;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+      }
+
+      .c8 {
+        border: none;
+        padding-left: 0;
+        padding-right: 16px;
+        padding-top: 12px;
+        padding-bottom: 12px;
+        color: #32324d;
+        font-weight: 400;
+        font-size: 0.875rem;
+        display: block;
+        width: 100%;
+      }
+
+      .c8::-webkit-input-placeholder {
+        color: #8e8ea9;
+        opacity: 1;
+      }
+
+      .c8::-moz-placeholder {
+        color: #8e8ea9;
+        opacity: 1;
+      }
+
+      .c8:-ms-input-placeholder {
+        color: #8e8ea9;
+        opacity: 1;
+      }
+
+      .c8::placeholder {
+        color: #8e8ea9;
+        opacity: 1;
+      }
+
+      .c8:disabled {
+        background: inherit;
+        color: inherit;
+      }
+
+      .c8:focus {
+        outline: none;
+      }
+
+      .c5 {
+        border: 1px solid #dcdce4;
+        border-radius: 4px;
+        background: #ffffff;
+        overflow: hidden;
+      }
+
+      .c5:focus-within {
+        border: 1px solid #4945ff;
+      }
+
+      .c1 > * {
+        margin-top: 0;
+        margin-bottom: 0;
+      }
+
+      .c1 > * + * {
+        margin-top: 4px;
+      }
+
+      .c0 textarea {
+        height: 5rem;
+      }
+
+      .c7 {
+        border: none;
+        background: transparent;
+        border-radius: 4px;
+      }
+
+      <div>
+        <div
+          class="c0"
+        >
+          <div>
+            <div
+              class="c1"
+            >
+              <div
+                class="c2"
+              >
+                <label
+                  class="c3"
+                  for="field-date-picker"
+                >
+                  Date picker
+                </label>
+              </div>
+              <div
+                class="c4 c5"
+              >
+                <div
+                  class="c6"
+                >
+                  <button
+                    aria-label="Date picker, current is 1"
+                    class="c7"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      height="1em"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.869 2.99V0h2.9v2.99h10.463V0h2.9v2.99h.629c2.768 0 3.203.498 3.239 2.926V21c0 2.124-.191 3-2.802 3H2.818C.208 24 0 23.363 0 20.785V6.21c.035-2.049.233-3.22 3.001-3.22h.868zM2.32 20.369c0 .811.245.865.776.865h17.905c.53 0 .68-.012.68-.825V8.233c-.015-.627-.219-.737-.631-.737H2.907c-.413 0-.592.09-.587.573v12.3z"
+                        fill="#32324D"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <input
+                  aria-autocomplete="none"
+                  aria-invalid="false"
+                  class="c8"
+                  id="field-date-picker"
+                  name="datepicker"
+                  placeholder="1"
+                  value="1"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `);
+  });
+});

--- a/packages/strapi-design-system/src/DatePicker/__tests__/generateWeeks.spec.js
+++ b/packages/strapi-design-system/src/DatePicker/__tests__/generateWeeks.spec.js
@@ -1,0 +1,136 @@
+import { generateWeeks } from '../generateWeeks';
+
+const makeDate = (day, month, year = 2021, outsideMonth = undefined) => {
+  if (outsideMonth) {
+    return { date: new Date(year, month, day), outsideMonth };
+  }
+
+  return { date: new Date(year, month, day) };
+};
+
+describe('generate weeks', () => {
+  it('verifies the matrix for january 2021', () => {
+    const jan = 0;
+    const dec = 11;
+    const feb = 1;
+
+    const weeksMatrix = [
+      [
+        makeDate(27, dec, 2020, true),
+        makeDate(28, dec, 2020, true),
+        makeDate(29, dec, 2020, true),
+        makeDate(30, dec, 2020, true),
+        makeDate(31, dec, 2020, true),
+        makeDate(1, jan),
+        makeDate(2, jan),
+      ],
+      [
+        makeDate(3, jan),
+        makeDate(4, jan),
+        makeDate(5, jan),
+        makeDate(6, jan),
+        makeDate(7, jan),
+        makeDate(8, jan),
+        makeDate(9, jan),
+      ],
+      [
+        makeDate(10, jan),
+        makeDate(11, jan),
+        makeDate(12, jan),
+        makeDate(13, jan),
+        makeDate(14, jan),
+        makeDate(15, jan),
+        makeDate(16, jan),
+      ],
+      [
+        makeDate(17, jan),
+        makeDate(18, jan),
+        makeDate(19, jan),
+        makeDate(20, jan),
+        makeDate(21, jan),
+        makeDate(22, jan),
+        makeDate(23, jan),
+      ],
+      [
+        makeDate(24, jan),
+        makeDate(25, jan),
+        makeDate(26, jan),
+        makeDate(27, jan),
+        makeDate(28, jan),
+        makeDate(29, jan),
+        makeDate(30, jan),
+      ],
+      [
+        makeDate(31, jan),
+        makeDate(1, feb, 2021, true),
+        makeDate(2, feb, 2021, true),
+        makeDate(3, feb, 2021, true),
+        makeDate(4, feb, 2021, true),
+        makeDate(5, feb, 2021, true),
+        makeDate(6, feb, 2021, true),
+      ],
+    ];
+
+    const [weeks] = generateWeeks(new Date(2021, jan, 26));
+
+    expect(weeks).toEqual(weeksMatrix);
+  });
+
+  it('verifies the matrix for february 2021', () => {
+    const feb = 1;
+    const jan = 0;
+    const mar = 2;
+
+    const weeksMatrix = [
+      [
+        makeDate(31, jan, 2021, true),
+        makeDate(1, feb),
+        makeDate(2, feb),
+        makeDate(3, feb),
+        makeDate(4, feb),
+        makeDate(5, feb),
+        makeDate(6, feb),
+      ],
+      [
+        makeDate(7, feb),
+        makeDate(8, feb),
+        makeDate(9, feb),
+        makeDate(10, feb),
+        makeDate(11, feb),
+        makeDate(12, feb),
+        makeDate(13, feb),
+      ],
+      [
+        makeDate(14, feb),
+        makeDate(15, feb),
+        makeDate(16, feb),
+        makeDate(17, feb),
+        makeDate(18, feb),
+        makeDate(19, feb),
+        makeDate(20, feb),
+      ],
+      [
+        makeDate(21, feb),
+        makeDate(22, feb),
+        makeDate(23, feb),
+        makeDate(24, feb),
+        makeDate(25, feb),
+        makeDate(26, feb),
+        makeDate(27, feb),
+      ],
+      [
+        makeDate(28, feb),
+        makeDate(1, mar, 2021, true),
+        makeDate(2, mar, 2021, true),
+        makeDate(3, mar, 2021, true),
+        makeDate(4, mar, 2021, true),
+        makeDate(5, mar, 2021, true),
+        makeDate(6, mar, 2021, true),
+      ],
+    ];
+
+    const [weeks] = generateWeeks(new Date(2021, 1, 26));
+
+    expect(weeks[0]).toEqual(weeksMatrix[0]);
+  });
+});

--- a/packages/strapi-design-system/src/DatePicker/compareDates.js
+++ b/packages/strapi-design-system/src/DatePicker/compareDates.js
@@ -1,0 +1,9 @@
+export const isDateEqual = (date1, date2) => {
+  if (!date1 || !date2) return false;
+
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDate() === date2.getDate()
+  );
+};

--- a/packages/strapi-design-system/src/DatePicker/generateWeeks.js
+++ b/packages/strapi-design-system/src/DatePicker/generateWeeks.js
@@ -1,0 +1,58 @@
+import { isDateEqual } from './compareDates';
+
+const CELL_COUNT = 7 * 6;
+
+/**
+ * This function output a matrix of 7x6 representing weeks and days in which each cell represents one day
+ * It starts by positioning the first day of the "date" month argument in the first row, at the good "day" position (monday, tuesday etc...)
+ * It then resolves the offset days and return the position of the "selectedDate" (if there's one)
+ * The output is: [weeks, activeRow, activeCol] where "weeks" is the matrix and "activeRow" and "activeCol" the coordinate of the select cell
+ */
+export const generateWeeks = (date, selectedDate) => {
+  const firstDayOfMonth = new Date(date.getFullYear(), date.getMonth(), 1);
+  const daysInCurrentMonth = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
+  const daysInPreviousMonth = new Date(date.getFullYear(), date.getMonth(), 0).getDate();
+
+  const preOffset = firstDayOfMonth.getDay();
+  const daysInMonthWithOffset = daysInCurrentMonth + preOffset;
+
+  const weeks = [];
+  let activeRow = 0;
+  let activeCol = 0;
+  let currentWeekIndex = 0;
+  let currentDate;
+
+  for (let i = 0; i < CELL_COUNT; i++) {
+    if (i > 6 && i % 7 === 0) {
+      currentWeekIndex++;
+    }
+
+    if (!weeks[currentWeekIndex]) {
+      weeks[currentWeekIndex] = [];
+    }
+
+    if (i < preOffset) {
+      currentDate = {
+        date: new Date(date.getFullYear(), date.getMonth() - 1, daysInPreviousMonth - preOffset + i + 1),
+        outsideMonth: true,
+      };
+    } else if (i < daysInMonthWithOffset) {
+      currentDate = { date: new Date(date.getFullYear(), date.getMonth(), i - preOffset + 1) };
+    } else {
+      currentDate = {
+        date: new Date(date.getFullYear(), date.getMonth() + 1, i - preOffset - daysInCurrentMonth + 1),
+        outsideMonth: true,
+      };
+    }
+
+    if (isDateEqual(selectedDate, currentDate.date)) {
+      activeRow = currentWeekIndex + 1;
+      activeCol = weeks[currentWeekIndex].length;
+      currentDate.isSelected = true;
+    }
+
+    weeks[currentWeekIndex].push(currentDate);
+  }
+
+  return [weeks, activeRow, activeCol];
+};

--- a/packages/strapi-design-system/src/DatePicker/getDayOfWeek.js
+++ b/packages/strapi-design-system/src/DatePicker/getDayOfWeek.js
@@ -1,0 +1,24 @@
+/**
+ * Hack method to retrieve the localized day of weeks
+ */
+export const getDayOfWeek = () => {
+  const format = new Intl.DateTimeFormat(undefined, { weekday: 'long' }).format;
+
+  const thu = new Date(1970, 0, 1);
+  const fri = new Date(1970, 0, 2);
+  const sat = new Date(1970, 0, 3);
+  const sun = new Date(1970, 0, 4);
+  const mon = new Date(1970, 0, 5);
+  const tue = new Date(1970, 0, 6);
+  const wed = new Date(1970, 0, 7);
+
+  return {
+    sun: format(sun),
+    mon: format(mon),
+    tue: format(tue),
+    wed: format(wed),
+    thu: format(thu),
+    fri: format(fri),
+    sat: format(sat),
+  };
+};

--- a/packages/strapi-design-system/src/DatePicker/index.js
+++ b/packages/strapi-design-system/src/DatePicker/index.js
@@ -1,0 +1,1 @@
+export * from './DatePicker';

--- a/packages/strapi-design-system/src/FocusTrap/FocusTrap.js
+++ b/packages/strapi-design-system/src/FocusTrap/FocusTrap.js
@@ -28,7 +28,7 @@ export const FocusTrap = ({ onEscape, restoreFocus, ...props }) => {
     const focusableChildren = getFocusableNodes(trappedRef.current);
 
     if (focusableChildren.length > 0) {
-      const firstElement = focusableChildren.item(0);
+      const firstElement = focusableChildren[0];
 
       firstElement.focus();
     } else {
@@ -48,8 +48,8 @@ export const FocusTrap = ({ onEscape, restoreFocus, ...props }) => {
     const focusableChildren = getFocusableNodes(trappedRef.current);
 
     if (focusableChildren.length > 0) {
-      const firstElement = focusableChildren.item(0);
-      const lastElement = focusableChildren.item(focusableChildren.length - 1);
+      const firstElement = focusableChildren[0];
+      const lastElement = focusableChildren[focusableChildren.length - 1];
 
       // e.shiftKey allows to verify reverse tab
       if (e.shiftKey) {

--- a/packages/strapi-design-system/src/Popover/Popover.js
+++ b/packages/strapi-design-system/src/Popover/Popover.js
@@ -1,6 +1,7 @@
 import React, { useRef, useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { useTheme } from '../ThemeProvider/hooks';
 import { Box } from '../Box';
 import { Portal } from '../Portal';
 

--- a/packages/strapi-design-system/src/Popover/Popover.js
+++ b/packages/strapi-design-system/src/Popover/Popover.js
@@ -1,7 +1,6 @@
-import React, { useRef, useLayoutEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { useTheme } from '../ThemeProvider/hooks';
 import { Box } from '../Box';
 import { Portal } from '../Portal';
 
@@ -19,7 +18,6 @@ const position = (source) => {
 
 const PopoverWrapper = styled(Box)`
   box-shadow: ${({ theme }) => theme.shadows.filterShadow};
-  display: ${({ visible }) => (visible ? 'block' : 'none')};
   position: absolute;
   border: 1px solid ${({ theme }) => theme.colors.neutral150};
   background: ${({ theme }) => theme.colors.neutral0};
@@ -46,31 +44,17 @@ const PopoverScrollable = styled(Box)`
   }
 `;
 
-export const Popover = ({ source, visible, children, spacingTop, ...props }) => {
-  const popoverRef = useRef(null);
+export const Popover = ({ source, children, spacingTop, ...props }) => {
+  const { left, top } = position(source.current);
 
-  useLayoutEffect(() => {
-    if (!popoverRef.current) return;
-
-    if (visible) {
-      const popover = popoverRef.current;
-      const { left, top } = position(source.current);
-
-      popover.style.left = `${left}px`;
-      popover.style.top = `${top}px`;
-    }
-  }, [visible]);
+  const style = {
+    left: `${left}px`,
+    top: `${top}px`,
+  };
 
   return (
     <Portal>
-      <PopoverWrapper
-        ref={popoverRef}
-        hasRadius
-        background="neutral0"
-        visible={visible}
-        padding={1}
-        spacingTop={spacingTop}
-      >
+      <PopoverWrapper style={style} hasRadius background="neutral0" padding={1} spacingTop={spacingTop}>
         <PopoverScrollable paddingRight={1} {...props}>
           {children}
         </PopoverScrollable>
@@ -83,5 +67,4 @@ Popover.propTypes = {
   children: PropTypes.node.isRequired,
   source: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   spacingTop: PropTypes.number,
-  visible: PropTypes.bool.isRequired,
 };

--- a/packages/strapi-design-system/src/Popover/Popover.stories.mdx
+++ b/packages/strapi-design-system/src/Popover/Popover.stories.mdx
@@ -7,10 +7,7 @@ import { Box } from '../Box';
 import { Button } from '../Button';
 import { Stack } from '../Stack';
 
-<Meta
-  title="Popover"
-  component={Popover}
-/>
+<Meta title="Popover" component={Popover} />
 
 # Popover
 
@@ -30,17 +27,19 @@ Description...
           <button ref={buttonRef} onClick={() => setVisible((s) => !s)}>
             Open popover
           </button>
-          <Popover source={buttonRef} visible={visible} spacingTop={4}>
-            <ul style={{ width: '200px' }}>
-              {Array(15)
-                .fill(null)
-                .map((_, index) => (
-                  <Box key={index} padding={3}>
-                    Element {index}
-                  </Box>
-                ))}
-            </ul>
-          </Popover>
+          {visible && (
+            <Popover source={buttonRef} spacingTop={4}>
+              <ul style={{ width: '200px' }}>
+                {Array(15)
+                  .fill(null)
+                  .map((_, index) => (
+                    <Box key={index} padding={3}>
+                      Element {index}
+                    </Box>
+                  ))}
+              </ul>
+            </Popover>
+          )}
         </Box>
       );
     }}

--- a/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.js
+++ b/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.js
@@ -12,7 +12,7 @@ describe('Popover', () => {
 
     const { container, getByText } = render(
       <ThemeProvider theme={lightTheme}>
-        <Popover source={{ current: source }} visible={true}>
+        <Popover source={{ current: source }}>
           <div>Hello world</div>
         </Popover>
       </ThemeProvider>,
@@ -36,7 +36,6 @@ describe('Popover', () => {
 
       .c1 {
         box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
-        display: block;
         position: absolute;
         border: 1px solid #eaeaef;
         background: #ffffff;
@@ -66,6 +65,7 @@ describe('Popover', () => {
       >
         <div
           class="c0 c1"
+          style="left: 0px; top: 0px;"
         >
           <div
             class="c2 c3"

--- a/packages/strapi-design-system/src/Table/Cell.js
+++ b/packages/strapi-design-system/src/Table/Cell.js
@@ -10,8 +10,8 @@ export const Td = ({ isFocusable, ...props }) => {
   const tdRef = useRef(null);
 
   useLayoutEffect(() => {
-    const focusableNodes = getFocusableNodes(tdRef.current);
-    const nextFocus = focusableNodes.item(0) || tdRef.current;
+    const focusableNodes = getFocusableNodes(tdRef.current, true);
+    const nextFocus = focusableNodes[0] || tdRef.current;
 
     nextFocus.setAttribute('tabIndex', isFocusable ? 0 : -1);
   }, [isFocusable]);

--- a/packages/strapi-design-system/src/Table/Table.js
+++ b/packages/strapi-design-system/src/Table/Table.js
@@ -4,14 +4,14 @@ import { TableContext } from './TableContext';
 import { KeyboardKeys } from '../helpers/keyboardKeys';
 import { focusFocusable } from './focusFocusable';
 
-export const Table = ({ colCount, rowCount, jumpStep, ...props }) => {
+export const Table = ({ colCount, rowCount, jumpStep, initialCol, initialRow, ...props }) => {
   const tableRef = useRef(null);
   const mountedRef = useRef(false);
   /**
    * Rows will always have n+1 line because of the <tr><th></th></tr> elements
    */
-  const [rowIndex, setRowIndex] = useState(0);
-  const [colIndex, setColIndex] = useState(0);
+  const [rowIndex, setRowIndex] = useState(initialRow);
+  const [colIndex, setColIndex] = useState(initialCol);
 
   useEffect(() => {
     if (mountedRef.current) {
@@ -105,10 +105,14 @@ export const Table = ({ colCount, rowCount, jumpStep, ...props }) => {
 
 Table.defaultProps = {
   jumpStep: 3,
+  initialCol: 0,
+  initialRow: 0,
 };
 
 Table.propTypes = {
   colCount: PropTypes.number.isRequired,
+  initialCol: PropTypes.number,
+  initialRow: PropTypes.number,
   jumpStep: PropTypes.number,
   rowCount: PropTypes.number.isRequired,
 };

--- a/packages/strapi-design-system/src/TextInput/TextInput.js
+++ b/packages/strapi-design-system/src/TextInput/TextInput.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useImperativeHandle, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Field, FieldLabel, FieldHint, FieldError, FieldInput, FieldAction } from '../Field';
 import { Stack } from '../Stack';
@@ -14,8 +14,14 @@ const TextInputWrapper = styled.div`
 
 export const TextInput = React.forwardRef(
   ({ leftAction, rightAction, name, hint, error, label, labelAction, id, ...props }, ref) => {
+    const inputWrapperRef = useRef(null);
+
+    useImperativeHandle(ref, () => ({
+      inputWrapperRef,
+    }));
+
     return (
-      <TextInputWrapper>
+      <TextInputWrapper ref={inputWrapperRef}>
         <Field name={name} hint={hint} error={error} id={id}>
           <Stack size={1}>
             <Row cols="auto auto 1fr" gap={1}>

--- a/packages/strapi-design-system/src/helpers/getFocusableNodes.js
+++ b/packages/strapi-design-system/src/helpers/getFocusableNodes.js
@@ -1,4 +1,17 @@
-export const getFocusableNodes = (node) =>
-  node.querySelectorAll(
-    'a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])',
-  );
+/**
+ * Sometimes, we want to retrieve the elements with tabindex=-1, and sometime we don't
+ * The includeNegativeTabIndex aims to provide this capability
+ */
+export const getFocusableNodes = (node, includeNegativeTabIndex) => {
+  const nodes = [
+    ...node.querySelectorAll('a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])'),
+  ];
+  const focusables = nodes.filter((node) => {
+    if (node.hasAttribute('disabled')) return false;
+    if (includeNegativeTabIndex) return true;
+
+    return node.getAttribute('tabindex') !== '-1';
+  });
+
+  return focusables;
+};


### PR DESCRIPTION
# DatePicker

## Description

Add a first iteration of DatePicker

## Demo

Example on : https://design-system-git-add-date-picker-strapijs.vercel.app/?path=/story/datepicker--base

## API

```jsx
<DatePicker
  // resolves a window.Date object
  onChange={setDate}
  selectedDate={date}
  label="Date picker"
  name="datepicker"
  selectedDateLabel={(formattedDate) => `Date picker, current is ${formattedDate}`}
/>
```

## Voiceover

![Navigating the date picker using voice over](https://user-images.githubusercontent.com/3874873/120168307-020a9000-c1ff-11eb-95df-a6de878eb7c6.gif)
