### PR TITLE
Make the focus trap aware of dynamic content

### DIFF
--- a/packages/strapi-design-system/src/FocusTrap/ExampleComponent.js
+++ b/packages/strapi-design-system/src/FocusTrap/ExampleComponent.js
@@ -10,6 +10,8 @@ import { Row } from '../Row';
 import { FocusTrap } from './FocusTrap';
 
 const TrappedComponent = ({ onClose }) => {
+  const [newLastVisible, setNewLastVisible] = useState(false);
+
   return (
     <FocusTrap onEscape={onClose}>
       <Box background="neutral0" padding={4} hasRadius style={{ width: '600px' }}>
@@ -31,7 +33,11 @@ const TrappedComponent = ({ onClose }) => {
           </Box>
           <Row justifyContent="space-between">
             <Button id="second">Second focusable</Button>
-            <Button id="last">Last focusable</Button>
+            <Button id="last" onClick={() => setNewLastVisible(true)}>
+              Last focusable (at the beginning)
+            </Button>
+
+            {newLastVisible && <Button id="real-last">Last focusable (at the end)</Button>}
           </Row>
         </Stack>
       </Box>

--- a/packages/strapi-design-system/src/FocusTrap/__tests__/FocusTrap.e2e.js
+++ b/packages/strapi-design-system/src/FocusTrap/__tests__/FocusTrap.e2e.js
@@ -58,6 +58,39 @@ describe('FocusTrap', () => {
         await expect(page).toHaveFocus('[aria-label="Close"]');
       },
     );
+
+    it.jestPlaywrightSkip(
+      { browsers: ['webkit'] },
+      'traps the focus when dynamically adding an element in the focus tree and pressing Tab for Firefox and Chrome',
+      async () => {
+        await page.keyboard.press('Tab');
+        await expect(page).toHaveFocus('#second');
+
+        await page.keyboard.press('Tab');
+        await expect(page).toHaveFocus('#last');
+        await page.click('#last');
+
+        await page.keyboard.press('Tab');
+        await expect(page).toHaveFocus('#real-last');
+      },
+    );
+
+    it.jestPlaywrightSkip(
+      { browsers: ['firefox', 'chromium'] },
+      'traps the focus when pressing Tab for Webkit',
+      async () => {
+        await page.waitForSelector('[aria-label="Close"]');
+        await page.keyboard.press('Alt+Tab');
+        await expect(page).toHaveFocus('#second');
+
+        await page.keyboard.press('Alt+Tab');
+        await expect(page).toHaveFocus('#last');
+        await page.click('#last');
+
+        await page.keyboard.press('Alt+Tab');
+        await expect(page).toHaveFocus('#real-last');
+      },
+    );
   });
 
   describe('Pressing Shift+Tab in the trap', () => {


### PR DESCRIPTION
# Fix focus trap bug

## Description

Before this PR, when dynamically showing content in the three (using a boolean state for instance), the focus tree was never updated because the listener was registered only at "mount time".

## Demo

Example on : [deployed story link]

## Record

![Focus trap rotating correctly](https://user-images.githubusercontent.com/3874873/119453210-7349cf00-bd37-11eb-8a4c-571ffb709b46.gif)
