### PR TITLE
Add Tabs

### DIFF
--- a/packages/strapi-design-system/src/Tabs/TabGroup.js
+++ b/packages/strapi-design-system/src/Tabs/TabGroup.js
@@ -1,0 +1,24 @@
+import React, { useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import { TabsContext } from './TabsContext';
+import { genId } from '../helpers/genId';
+
+export const TabGroup = ({ id, label, ...props }) => {
+  const tabsId = useRef(id || genId());
+  const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+
+  return (
+    <TabsContext.Provider value={{ id: tabsId.current, selectedTabIndex, selectTabIndex: setSelectedTabIndex, label }}>
+      <div {...props} />
+    </TabsContext.Provider>
+  );
+};
+
+TabGroup.defaultProps = {
+  id: undefined,
+};
+
+TabGroup.propTypes = {
+  id: PropTypes.string,
+  label: PropTypes.string.isRequired,
+};

--- a/packages/strapi-design-system/src/Tabs/TabPanels.js
+++ b/packages/strapi-design-system/src/Tabs/TabPanels.js
@@ -1,0 +1,32 @@
+import React, { Children, cloneElement } from 'react';
+import PropTypes from 'prop-types';
+import { useTabs } from './TabsContext';
+
+export const TabPanels = ({ children, ...props }) => {
+  const { id, selectedTabIndex } = useTabs();
+
+  const childrenArray = Children.toArray(children)
+    .map((node, index) => cloneElement(node, { id: `${id}-${index}` }))
+    .filter((_, index) => index === selectedTabIndex);
+
+  return <div {...props}>{childrenArray}</div>;
+};
+
+TabPanels.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const TabPanel = ({ id, ...props }) => {
+  const tabId = `tab-${id}`;
+  const tabPanelId = `tab-panel-${id}`;
+
+  return <div id={tabPanelId} role="tabpanel" tabIndex={0} aria-labelledby={tabId} {...props} />;
+};
+
+TabPanel.defaultProps = {
+  id: undefined,
+};
+
+TabPanel.propTypes = {
+  id: PropTypes.string,
+};

--- a/packages/strapi-design-system/src/Tabs/Tabs.js
+++ b/packages/strapi-design-system/src/Tabs/Tabs.js
@@ -31,6 +31,14 @@ const TabsRow = styled(Row)`
   & > * {
     flex: 1;
   }
+
+  & ${TabButton}:first-of-type ${TabBox} {
+    border-radius: ${({ theme }) => `${theme.borderRadius} 0 0 0`};
+  }
+
+  & ${TabButton}:last-of-type ${TabBox} {
+    border-radius: ${({ theme }) => `0 ${theme.borderRadius} 0 0`};
+  }
 `;
 
 export const Tabs = ({ children, ...props }) => {

--- a/packages/strapi-design-system/src/Tabs/Tabs.js
+++ b/packages/strapi-design-system/src/Tabs/Tabs.js
@@ -11,7 +11,7 @@ import { useTabsFocus } from './useTabsFocus';
 
 const TabBox = styled(Box)`
   border-bottom: 1px solid ${({ theme, selected }) => (selected ? theme.colors.neutral0 : theme.colors.neutral150)};
-  border-radius: 4px 4px 0 0;
+  border-radius: ${({ theme, selected }) => (selected ? `${theme.borderRadius} ${theme.borderRadius} 0 0` : undefined)};
 `;
 
 const TabButton = styled.button`

--- a/packages/strapi-design-system/src/Tabs/Tabs.js
+++ b/packages/strapi-design-system/src/Tabs/Tabs.js
@@ -1,0 +1,123 @@
+import React, { Children, cloneElement, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Box } from '../Box';
+import { useTabs } from './TabsContext';
+import { Row } from '../Row';
+import { TextButton } from '../Text';
+
+import { KeyboardKeys } from '../helpers/keyboardKeys';
+import { useTabsFocus } from './useTabsFocus';
+
+const TabBox = styled(Box)`
+  border-bottom: 1px solid ${({ theme, selected }) => (selected ? theme.colors.neutral0 : theme.colors.neutral150)};
+  border-radius: 4px 4px 0 0;
+`;
+
+const TabButton = styled.button`
+  border: none;
+  background: transparent;
+  padding: 0;
+
+  & + & > ${TabBox} {
+    border-left: 1px solid ${({ theme }) => theme.colors.neutral150};
+  }
+
+  // Hack preventing the outline from being overflow by the following tab
+  outline-offset: -2px;
+`;
+
+const TabsRow = styled(Row)`
+  & > * {
+    flex: 1;
+  }
+`;
+
+export const Tabs = ({ children, ...props }) => {
+  const { id, selectedTabIndex, selectTabIndex, label } = useTabs();
+  const tabsRef = useTabsFocus(selectedTabIndex);
+
+  const childrenArray = Children.toArray(children).map((node, index) =>
+    cloneElement(node, {
+      id: `${id}-${index}`,
+      selected: index === selectedTabIndex,
+      onClick: () => selectTabIndex(index),
+    }),
+  );
+
+  const handleKeyDown = (e) => {
+    switch (e.key) {
+      case KeyboardKeys.ARROW_RIGHT: {
+        const nextIndex = selectedTabIndex + 1;
+        selectTabIndex(nextIndex >= childrenArray.length ? 0 : nextIndex);
+
+        break;
+      }
+
+      case KeyboardKeys.ARROW_LEFT: {
+        const nextIndex = selectedTabIndex - 1;
+        selectTabIndex(nextIndex < 0 ? childrenArray.length - 1 : nextIndex);
+
+        break;
+      }
+
+      case KeyboardKeys.HOME: {
+        selectTabIndex(0);
+
+        break;
+      }
+
+      case KeyboardKeys.END: {
+        selectTabIndex(childrenArray.length - 1);
+
+        break;
+      }
+
+      default:
+        break;
+    }
+  };
+
+  return (
+    <TabsRow ref={tabsRef} role="tablist" alignItems="flex-end" aria-label={label} onKeyDown={handleKeyDown} {...props}>
+      {childrenArray}
+    </TabsRow>
+  );
+};
+
+Tabs.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const Tab = ({ selected, id, children, ...props }) => {
+  const tabId = `tab-${id}`;
+  const tabPanelId = `tab-panel-${id}`;
+
+  return (
+    <TabButton
+      id={tabId}
+      role="tab"
+      aria-controls={selected ? tabPanelId : undefined}
+      tabIndex={selected ? 0 : -1}
+      aria-selected={selected}
+      {...props}
+    >
+      <TabBox padding={selected ? 4 : 3} background={selected ? 'neutral0' : 'neutral100'} selected={selected}>
+        <TextButton as="span" textColor={selected ? 'primary700' : 'neutral600'}>
+          {children}
+        </TextButton>
+      </TabBox>
+    </TabButton>
+  );
+};
+
+Tab.defaultProps = {
+  selected: false,
+  id: undefined,
+};
+
+Tab.propTypes = {
+  children: PropTypes.node.isRequired,
+  id: PropTypes.string,
+  selected: PropTypes.bool,
+};

--- a/packages/strapi-design-system/src/Tabs/Tabs.stories.mdx
+++ b/packages/strapi-design-system/src/Tabs/Tabs.stories.mdx
@@ -37,9 +37,21 @@ Description...
           <Tab>Third</Tab>
         </Tabs>
         <TabPanels>
-          <TabPanel>First panel</TabPanel>
-          <TabPanel>Second panel</TabPanel>
-          <TabPanel>Third panel</TabPanel>
+          <TabPanel>
+            <Box padding={4} background="neutral0">
+              First panel
+            </Box>
+          </TabPanel>
+          <TabPanel>
+            <Box padding={4} background="neutral0">
+              Second panel
+            </Box>
+          </TabPanel>
+          <TabPanel>
+            <Box padding={4} background="neutral0">
+              Third panel
+            </Box>
+          </TabPanel>
         </TabPanels>
       </TabGroup>
     </Box>

--- a/packages/strapi-design-system/src/Tabs/Tabs.stories.mdx
+++ b/packages/strapi-design-system/src/Tabs/Tabs.stories.mdx
@@ -1,0 +1,59 @@
+<!--- Tabs.stories.mdx --->
+
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { withDesign } from 'storybook-addon-designs';
+import { Tabs, Tab } from './Tabs';
+import { TabGroup } from './TabGroup';
+import { TabPanels, TabPanel } from './TabPanels';
+import { Box } from '../Box';
+
+<Meta
+  title="Tabs"
+  component={Tabs}
+  decorators={[withDesign]}
+  parameters={{
+    design: {
+      type: 'figma',
+      url: 'TODO: Fill the according figma file',
+    },
+  }}
+/>
+
+# Tabs
+
+This is the doc of the `Tabs` component
+
+## Tabs
+
+Description...
+
+<Canvas>
+  <Story name="base">
+    <Box padding={8} background="primary100">
+      <TabGroup label="Some stuff for the label" id="tabs">
+        <Tabs>
+          <Tab>First</Tab>
+          <Tab>Second</Tab>
+          <Tab>Third</Tab>
+        </Tabs>
+        <TabPanels>
+          <TabPanel>
+            <Box padding={4} background="neutral0">
+              First panel
+            </Box>
+          </TabPanel>
+          <TabPanel>
+            <Box padding={4} background="neutral0">
+              Second panel
+            </Box>
+          </TabPanel>
+          <TabPanel>
+            <Box padding={4} background="neutral0">
+              Third panel
+            </Box>
+          </TabPanel>
+        </TabPanels>
+      </TabGroup>
+    </Box>
+  </Story>
+</Canvas>

--- a/packages/strapi-design-system/src/Tabs/Tabs.stories.mdx
+++ b/packages/strapi-design-system/src/Tabs/Tabs.stories.mdx
@@ -37,21 +37,9 @@ Description...
           <Tab>Third</Tab>
         </Tabs>
         <TabPanels>
-          <TabPanel>
-            <Box padding={4} background="neutral0">
-              First panel
-            </Box>
-          </TabPanel>
-          <TabPanel>
-            <Box padding={4} background="neutral0">
-              Second panel
-            </Box>
-          </TabPanel>
-          <TabPanel>
-            <Box padding={4} background="neutral0">
-              Third panel
-            </Box>
-          </TabPanel>
+          <TabPanel>First panel</TabPanel>
+          <TabPanel>Second panel</TabPanel>
+          <TabPanel>Third panel</TabPanel>
         </TabPanels>
       </TabGroup>
     </Box>

--- a/packages/strapi-design-system/src/Tabs/TabsContext.js
+++ b/packages/strapi-design-system/src/Tabs/TabsContext.js
@@ -1,0 +1,5 @@
+import { createContext, useContext } from 'react';
+
+export const TabsContext = createContext();
+
+export const useTabs = () => useContext(TabsContext);

--- a/packages/strapi-design-system/src/Tabs/__tests__/Tabs.e2e.js
+++ b/packages/strapi-design-system/src/Tabs/__tests__/Tabs.e2e.js
@@ -1,0 +1,115 @@
+import { injectAxe, checkA11y } from 'axe-playwright';
+
+describe('Tabs', () => {
+  beforeEach(async () => {
+    // This is the URL of the Storybook Iframe
+    await page.goto('http://localhost:6006/iframe.html?id=tabs--base&viewMode=story');
+    await injectAxe(page);
+  });
+
+  it('triggers axe on the document', async () => {
+    await checkA11y(page);
+  });
+
+  it('verifies that only the first panel is visible at the beginning', async () => {
+    const isFirstPanelVisible = await page.isVisible('text="First panel"');
+    expect(isFirstPanelVisible).toBeTruthy();
+
+    const isSecondPanelVisible = await page.isVisible('text="Second panel"');
+    expect(isSecondPanelVisible).toBeFalsy();
+
+    const isThirdPanelVisible = await page.isVisible('text="Third panel"');
+    expect(isThirdPanelVisible).toBeFalsy();
+  });
+
+  describe('Click interactions', () => {
+    it('shows only the first panel when clicking on it', async () => {
+      await page.click('text="Second"');
+      await page.click('text="First"');
+
+      const isFirstPanelVisible = await page.isVisible('text="First panel"');
+      expect(isFirstPanelVisible).toBeTruthy();
+
+      const isSecondPanelVisible = await page.isVisible('text="Second panel"');
+      expect(isSecondPanelVisible).toBeFalsy();
+
+      const isThirdPanelVisible = await page.isVisible('text="Third panel"');
+      expect(isThirdPanelVisible).toBeFalsy();
+    });
+
+    it('shows only the second panel when clicking on it', async () => {
+      await page.click('text="Second"');
+
+      const isFirstPanelVisible = await page.isVisible('text="First panel"');
+      expect(isFirstPanelVisible).toBeFalsy();
+
+      const isSecondPanelVisible = await page.isVisible('text="Second panel"');
+      expect(isSecondPanelVisible).toBeTruthy();
+
+      const isThirdPanelVisible = await page.isVisible('text="Third panel"');
+      expect(isThirdPanelVisible).toBeFalsy();
+    });
+
+    it('shows only the third panel when clicking on it', async () => {
+      await page.click('text="Third"');
+
+      const isFirstPanelVisible = await page.isVisible('text="First panel"');
+      expect(isFirstPanelVisible).toBeFalsy();
+
+      const isSecondPanelVisible = await page.isVisible('text="Second panel"');
+      expect(isSecondPanelVisible).toBeFalsy();
+
+      const isThirdPanelVisible = await page.isVisible('text="Third panel"');
+      expect(isThirdPanelVisible).toBeTruthy();
+    });
+  });
+
+  describe('Keyboard interactions', () => {
+    it('moves to the next tab when pressing ArrowRight', async () => {
+      await page.waitForSelector('#tab-tabs-0');
+
+      await page.focus('#tab-tabs-0');
+      await page.keyboard.press('ArrowRight');
+      await expect(page).toHaveFocus('#tab-tabs-1');
+
+      await page.keyboard.press('ArrowRight');
+      await expect(page).toHaveFocus('#tab-tabs-2');
+
+      await page.keyboard.press('ArrowRight');
+      await expect(page).toHaveFocus('#tab-tabs-0');
+    });
+
+    it('moves to the previous tab when pressing ArrowLeft', async () => {
+      await page.waitForSelector('#tab-tabs-0');
+
+      await page.focus('#tab-tabs-0');
+      await page.keyboard.press('ArrowLeft');
+      await expect(page).toHaveFocus('#tab-tabs-2');
+
+      await page.keyboard.press('ArrowLeft');
+      await expect(page).toHaveFocus('#tab-tabs-1');
+
+      await page.keyboard.press('ArrowLeft');
+      await expect(page).toHaveFocus('#tab-tabs-0');
+    });
+
+    it('moves to the first tab when pressing Home', async () => {
+      await page.waitForSelector('#tab-tabs-0');
+
+      await page.focus('#tab-tabs-0');
+      await page.keyboard.press('ArrowLeft');
+      await page.keyboard.press('Home');
+
+      await expect(page).toHaveFocus('#tab-tabs-0');
+    });
+
+    it('moves to the last tab when pressing End', async () => {
+      await page.waitForSelector('#tab-tabs-0');
+
+      await page.focus('#tab-tabs-0');
+      await page.keyboard.press('End');
+
+      await expect(page).toHaveFocus('#tab-tabs-2');
+    });
+  });
+});

--- a/packages/strapi-design-system/src/Tabs/__tests__/Tabs.spec.js
+++ b/packages/strapi-design-system/src/Tabs/__tests__/Tabs.spec.js
@@ -76,7 +76,6 @@ describe('Tabs', () => {
 
       .c10 {
         border-bottom: 1px solid #eaeaef;
-        border-radius: 4px 4px 0 0;
       }
 
       .c3 {

--- a/packages/strapi-design-system/src/Tabs/__tests__/Tabs.spec.js
+++ b/packages/strapi-design-system/src/Tabs/__tests__/Tabs.spec.js
@@ -1,0 +1,171 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+import { Tabs, Tab } from '../Tabs';
+import { TabGroup } from '../TabGroup';
+import { TabPanels, TabPanel } from '../TabPanels';
+
+describe('Tabs', () => {
+  it('snapshots the component', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <TabGroup label="Some stuff for the label" id="tabs">
+          <Tabs>
+            <Tab>First</Tab>
+            <Tab>Second</Tab>
+            <Tab>Third</Tab>
+          </Tabs>
+          <TabPanels>
+            <TabPanel>First panel</TabPanel>
+            <TabPanel>Second panel</TabPanel>
+            <TabPanel>Third panel</TabPanel>
+          </TabPanels>
+        </TabGroup>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c5 {
+        background: #ffffff;
+        padding: 16px;
+      }
+
+      .c9 {
+        background: #f6f6f9;
+        padding: 12px;
+      }
+
+      .c0 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-align-items: flex-end;
+        -webkit-box-align: flex-end;
+        -ms-flex-align: flex-end;
+        align-items: flex-end;
+      }
+
+      .c7 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #271fe0;
+      }
+
+      .c11 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #666687;
+      }
+
+      .c8 {
+        font-weight: 600;
+        line-height: 1.14;
+      }
+
+      .c6 {
+        border-bottom: 1px solid #ffffff;
+        border-radius: 4px 4px 0 0;
+      }
+
+      .c10 {
+        border-bottom: 1px solid #eaeaef;
+        border-radius: 4px 4px 0 0;
+      }
+
+      .c3 {
+        border: none;
+        background: transparent;
+        padding: 0;
+        outline-offset: -2px;
+      }
+
+      .c2 + .c2 > .c4 {
+        border-left: 1px solid #eaeaef;
+      }
+
+      .c1 > * {
+        -webkit-flex: 1;
+        -ms-flex: 1;
+        flex: 1;
+      }
+
+      <div>
+        <div
+          aria-label="Some stuff for the label"
+          class="c0 c1"
+          role="tablist"
+        >
+          <button
+            aria-controls="tab-panel-tabs-0"
+            aria-selected="true"
+            class="c2 c3"
+            id="tab-tabs-0"
+            role="tab"
+            tabindex="0"
+          >
+            <div
+              class="c4 c5 c6"
+            >
+              <span
+                class="c7 c8"
+              >
+                First
+              </span>
+            </div>
+          </button>
+          <button
+            aria-selected="false"
+            class="c2 c3"
+            id="tab-tabs-1"
+            role="tab"
+            tabindex="-1"
+          >
+            <div
+              class="c4 c9 c10"
+            >
+              <span
+                class="c11 c8"
+              >
+                Second
+              </span>
+            </div>
+          </button>
+          <button
+            aria-selected="false"
+            class="c2 c3"
+            id="tab-tabs-2"
+            role="tab"
+            tabindex="-1"
+          >
+            <div
+              class="c4 c9 c10"
+            >
+              <span
+                class="c11 c8"
+              >
+                Third
+              </span>
+            </div>
+          </button>
+        </div>
+        <div>
+          <div
+            aria-labelledby="tab-tabs-0"
+            id="tab-panel-tabs-0"
+            role="tabpanel"
+            tabindex="0"
+          >
+            First panel
+          </div>
+        </div>
+      </div>
+    `);
+  });
+});

--- a/packages/strapi-design-system/src/Tabs/__tests__/Tabs.spec.js
+++ b/packages/strapi-design-system/src/Tabs/__tests__/Tabs.spec.js
@@ -95,6 +95,14 @@ describe('Tabs', () => {
         flex: 1;
       }
 
+      .c1 .c2:first-of-type .c4 {
+        border-radius: 4px 0 0 0;
+      }
+
+      .c1 .c2:last-of-type .c4 {
+        border-radius: 0 4px 0 0;
+      }
+
       <div>
         <div
           aria-label="Some stuff for the label"

--- a/packages/strapi-design-system/src/Tabs/index.js
+++ b/packages/strapi-design-system/src/Tabs/index.js
@@ -1,0 +1,3 @@
+export * from './Tabs';
+export * from './TabPanels';
+export * from './TabGroup';

--- a/packages/strapi-design-system/src/Tabs/useTabsFocus.js
+++ b/packages/strapi-design-system/src/Tabs/useTabsFocus.js
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react';
+
+export const useTabsFocus = (selectedTabIndex) => {
+  const tabsRef = useRef(null);
+  const mountedRef = useRef(null);
+
+  useEffect(() => {
+    if (!tabsRef.current) return;
+
+    // We don't' want to send the focus to the tab when it mounts
+    // It could break the navigating flow of the users if the focus was supposed to be
+    // on another element
+    if (mountedRef.current) {
+      const nextFocusEl = tabsRef.current.querySelector('[tabindex="0"]');
+
+      if (nextFocusEl) {
+        nextFocusEl.focus();
+      }
+    }
+
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+    }
+  }, [selectedTabIndex]);
+
+  return tabsRef;
+};

--- a/packages/strapi-design-system/src/index.js
+++ b/packages/strapi-design-system/src/index.js
@@ -24,6 +24,7 @@ export * from './Searchbar';
 export * from './Stack';
 export * from './Switch';
 export * from './Table';
+export * from './Tabs';
 export * from './Tag';
 export * from './Text';
 export * from './TextButton';


### PR DESCRIPTION
# Add Tabs

## Description

Add a tabs panel:

- when one of the tab is focused, pressing arrow right moves to the next one (or the first one if the focused item is the last)
- when one of the tab is focused, pressing arrow left moves to the previous one (or the last one if the focused item is the first)
- when one of the tab is focused, pressing home moves to the first tab
- when one of the tab is focused, pressing last moves to the last tab
- pressing tab outside the list sends the focus to the lastly focused tab (or the first one if it has never been selected)
- pressing tab inside the list when a tab is already focused sends the focus to the according tab panel for reading purpose

## Demo

⚠️ make sure to hard refresh

Example on : https://design-system-git-add-tabs-strapijs.vercel.app/?path=/story/tabs--base

## API

```jsx
<TabGroup label="Some stuff for the label" id="tabs">
  <Tabs>
    <Tab>First</Tab>
    <Tab>Second</Tab>
    <Tab>Third</Tab>
  </Tabs>
  <TabPanels>
    <TabPanel>First panel</TabPanel>
    <TabPanel>Second panel</TabPanel>
    <TabPanel>Third panel</TabPanel>
  </TabPanels>
</TabGroup>
```

## Voiceover

![The tabs component used with VoiceOver](https://user-images.githubusercontent.com/3874873/119621913-f554f900-be06-11eb-94d6-5a1cdf0b8b1f.gif)
