### PR TITLE
Simple menu

### DIFF
--- a/packages/strapi-design-system/src/Popover/Popover.js
+++ b/packages/strapi-design-system/src/Popover/Popover.js
@@ -29,11 +29,6 @@ const PopoverScrollable = styled(Box)`
   max-height: ${3 * 5}rem;
   overflow-y: scroll;
 
-  &::-webkit-scrollbar {
-    position: absolute;
-    width: ${({ theme }) => theme.spaces[1]};
-  }
-
   &::-webkit-scrollbar-track {
     background: ${({ theme }) => theme.colors.neutral0};
   }

--- a/packages/strapi-design-system/src/Popover/Popover.js
+++ b/packages/strapi-design-system/src/Popover/Popover.js
@@ -30,6 +30,7 @@ const PopoverScrollable = styled(Box)`
   overflow-y: scroll;
 
   &::-webkit-scrollbar {
+    position: absolute;
     width: ${({ theme }) => theme.spaces[1]};
   }
 
@@ -55,9 +56,7 @@ export const Popover = ({ source, children, spacingTop, ...props }) => {
   return (
     <Portal>
       <PopoverWrapper style={style} hasRadius background="neutral0" padding={1} spacingTop={spacingTop}>
-        <PopoverScrollable paddingRight={1} {...props}>
-          {children}
-        </PopoverScrollable>
+        <PopoverScrollable {...props}>{children}</PopoverScrollable>
       </PopoverWrapper>
     </Portal>
   );

--- a/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.js
+++ b/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.js
@@ -30,10 +30,6 @@ describe('Popover', () => {
         border-radius: 4px;
       }
 
-      .c2 {
-        padding-right: 4px;
-      }
-
       .c1 {
         box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
         position: absolute;
@@ -41,20 +37,21 @@ describe('Popover', () => {
         background: #ffffff;
       }
 
-      .c3 {
+      .c2 {
         max-height: 15rem;
         overflow-y: scroll;
       }
 
-      .c3::-webkit-scrollbar {
+      .c2::-webkit-scrollbar {
+        position: absolute;
         width: 4px;
       }
 
-      .c3::-webkit-scrollbar-track {
+      .c2::-webkit-scrollbar-track {
         background: #ffffff;
       }
 
-      .c3::-webkit-scrollbar-thumb {
+      .c2::-webkit-scrollbar-thumb {
         background: #eaeaef;
         border-radius: 4px;
         margin-right: 10px;
@@ -68,7 +65,7 @@ describe('Popover', () => {
           style="left: 0px; top: 0px;"
         >
           <div
-            class="c2 c3"
+            class="c2"
           >
             <div>
               Hello world

--- a/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.js
+++ b/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.js
@@ -42,11 +42,6 @@ describe('Popover', () => {
         overflow-y: scroll;
       }
 
-      .c2::-webkit-scrollbar {
-        position: absolute;
-        width: 4px;
-      }
-
       .c2::-webkit-scrollbar-track {
         background: #ffffff;
       }

--- a/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
+++ b/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
@@ -1,0 +1,51 @@
+import React, { useRef, useState } from 'react';
+import styled from 'styled-components';
+import FilterDropdown from '@strapi/icons/FilterDropdown';
+import { Text } from '../Text';
+import { Row } from '../Row';
+import { Box } from '../Box';
+import { Popover } from '../Popover';
+
+const MenuButton = styled.button`
+  border: none;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  font-size: ${12 / 16}rem;
+  svg {
+    height: 4px;
+  }
+`;
+
+export const SimpleMenu = () => {
+  const menuRef = useRef();
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <div>
+      <MenuButton onClick={() => setVisible((s) => !s)} ref={menuRef}>
+        <Box paddingRight={1}>
+          <Text>January</Text>
+        </Box>
+        <FilterDropdown />
+      </MenuButton>
+      {visible && (
+        <Popover source={menuRef} spacingTop={1}>
+          <ul>
+            {Array(15)
+              .fill(null)
+              .map((_, index) => (
+                <Box key={index} padding={2}>
+                  Element {index}
+                </Box>
+              ))}
+          </ul>
+        </Popover>
+      )}
+    </div>
+  );
+};
+
+SimpleMenu.displayName = 'SimpleMenu';
+
+SimpleMenu.propTypes = {};

--- a/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
+++ b/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, Children, cloneElement } from 'react';
+import React, { useRef, useState, Children, cloneElement, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import FilterDropdown from '@strapi/icons/FilterDropdown';
@@ -7,6 +7,8 @@ import { Box } from '../Box';
 import { Row } from '../Row';
 import { Popover } from '../Popover';
 import { getOptionStyle } from './utils';
+import { useId } from '../helpers/useId';
+import { KeyboardKeys } from '../helpers/keyboardKeys';
 
 const OptionButton = styled.button`
   border: none;
@@ -30,42 +32,83 @@ const MenuButton = styled.button`
   }
 `;
 
-export const MenuItem = ({ children, onClick, href, ...props }) => {
-  if (href) {
-    return (
-      <Row as="li" justyfiContent="center">
-        <OptionLink href={href} {...props}>
-          <Box padding={2}>
-            <Text>{children}</Text>
-          </Box>
-        </OptionLink>
-      </Row>
-    );
-  }
+export const MenuItem = ({ children, onClick, href, isFocused, ...props }) => {
+  const menuItemRef = useRef();
+
+  useEffect(() => {
+    if (isFocused && menuItemRef.current) {
+      menuItemRef.current.focus();
+    }
+  }, [isFocused]);
+
+  const menuItemProps = {
+    tabIndex: -1,
+    ref: menuItemRef,
+    role: 'menuItem',
+    isFocused,
+    ...props,
+  };
 
   return (
-    <Row as="li" justyfiContent="center">
-      <OptionButton onClick={onClick} {...props}>
-        <Box padding={2}>
-          <Text>{children}</Text>
-        </Box>
-      </OptionButton>
+    <Row as="li" justifyContent="center">
+      {href ? (
+        <OptionLink href={href} {...menuItemProps}>
+          <Box padding={2}>
+            <Text as="span">{children}</Text>
+          </Box>
+        </OptionLink>
+      ) : (
+        <OptionButton onClick={onClick} {...menuItemProps}>
+          <Box padding={2}>
+            <Text as="span">{children}</Text>
+          </Box>
+        </OptionButton>
+      )}
     </Row>
   );
 };
 MenuItem.defaultProps = {
   onClick: () => {},
   href: undefined,
+  isFocused: false,
 };
 MenuItem.propTypes = {
   children: PropTypes.string.isRequired,
   href: PropTypes.string,
+  isFocused: PropTypes.bool,
   onClick: PropTypes.func,
 };
 
 export const SimpleMenu = ({ label, children, ...props }) => {
   const menuButtonRef = useRef();
+  const menuId = useId('simpleMenu');
   const [visible, setVisible] = useState(false);
+  const [focusedItemIndex, setFocusItem] = useState(0);
+  const childrenArray = Children.toArray(children);
+
+  const handleWrapperKeyDown = (e) => {
+    if (visible) {
+      if (e.key === KeyboardKeys.ESCAPE) {
+        setVisible(false);
+        setFocusItem(0);
+      }
+      if (e.key === KeyboardKeys.TAB) return;
+
+      if (e.key === KeyboardKeys.DOWN && focusedItemIndex < childrenArray.length - 1) {
+        setFocusItem((prev) => prev + 1);
+      }
+
+      if (e.key === KeyboardKeys.UP && focusedItemIndex > 0) {
+        setFocusItem((prev) => prev - 1);
+      }
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === KeyboardKeys.ENTER) {
+      setVisible((prevVisible) => !prevVisible);
+    }
+  };
 
   const handleBlur = (e) => {
     if (!e.currentTarget.contains(e.relatedTarget)) {
@@ -73,26 +116,40 @@ export const SimpleMenu = ({ label, children, ...props }) => {
     }
   };
 
-  const childrenClone = Children.toArray(children).map((child) =>
+  const handleMenuButtonClick = () => {
+    setVisible((prevVisible) => !prevVisible);
+  };
+
+  const childrenClone = childrenArray.map((child, index) =>
     cloneElement(child, {
       onClick: () => {
         setVisible(false);
+        setFocusItem(0);
         child.props.onClick();
       },
+      isFocused: focusedItemIndex === index,
     }),
   );
 
   return (
-    <div>
-      <MenuButton {...props} onClick={() => setVisible((s) => !s)} ref={menuButtonRef}>
+    <div onKeyDown={handleWrapperKeyDown}>
+      <MenuButton
+        aria-haspopup
+        aria-expanded={visible}
+        aria-controls={menuId}
+        {...props}
+        onKeyDown={handleKeyDown}
+        onMouseDown={handleMenuButtonClick}
+        ref={menuButtonRef}
+      >
         <Box paddingRight={1}>
           <TextButton>{label}</TextButton>
         </Box>
         <FilterDropdown aria-hidden />
       </MenuButton>
       {visible && (
-        <Popover tabindex="0" onBlur={handleBlur} source={menuButtonRef} spacingTop={1}>
-          <Box as="ul" padding={1}>
+        <Popover onBlur={handleBlur} source={menuButtonRef} spacingTop={1}>
+          <Box role="menu" as="ul" padding={1}>
             {childrenClone}
           </Box>
         </Popover>

--- a/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
+++ b/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
@@ -28,7 +28,10 @@ const MenuButton = styled.button`
   align-items: center;
   font-size: ${12 / 16}rem;
   svg {
-    height: 4px;
+    height: ${4 / 16}rem;
+    path {
+      fill: ${({ theme }) => theme.colors.neutral500};
+    }
   }
 `;
 
@@ -105,18 +108,21 @@ export const SimpleMenu = ({ label, children, ...props }) => {
   };
 
   const handleKeyDown = (e) => {
-    if (e.key === KeyboardKeys.ENTER) {
-      setVisible((prevVisible) => !prevVisible);
+    switch (e.key) {
+      case KeyboardKeys.SPACE:
+      case KeyboardKeys.ENTER: {
+        setVisible((prevVisible) => !prevVisible);
+      }
     }
   };
 
   const handleBlur = (e) => {
-    // if (!e.currentTarget.contains(e.relatedTarget)) {
-    //   setVisible(false);
-    // }
+    if (!e.currentTarget.contains(e.relatedTarget)) {
+      setVisible(false);
+    }
   };
 
-  const handleMenuButtonClick = () => {
+  const handleMenuButtonMouseDown = () => {
     setVisible((prevVisible) => !prevVisible);
   };
 
@@ -124,7 +130,6 @@ export const SimpleMenu = ({ label, children, ...props }) => {
     cloneElement(child, {
       onClick: () => {
         child.props.onClick();
-        // setFocusItem(0);
         setVisible(false);
         menuButtonRef.current.focus();
       },
@@ -139,12 +144,12 @@ export const SimpleMenu = ({ label, children, ...props }) => {
         aria-expanded={visible}
         aria-controls={menuId}
         onKeyDown={handleKeyDown}
-        onMouseDown={handleMenuButtonClick}
+        onMouseDown={handleMenuButtonMouseDown}
         ref={menuButtonRef}
         {...props}
       >
         <Box paddingRight={1}>
-          <TextButton>{label}</TextButton>
+          <TextButton as="span">{label}</TextButton>
         </Box>
         <FilterDropdown aria-hidden />
       </MenuButton>

--- a/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
+++ b/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
@@ -42,9 +42,9 @@ export const MenuItem = ({ children, onClick, href, isFocused, ...props }) => {
   }, [isFocused]);
 
   const menuItemProps = {
-    tabIndex: -1,
+    tabIndex: isFocused ? 0 : -1,
     ref: menuItemRef,
-    role: 'menuItem',
+    role: 'menuitem',
     isFocused,
     ...props,
   };
@@ -91,15 +91,15 @@ export const SimpleMenu = ({ label, children, ...props }) => {
       if (e.key === KeyboardKeys.ESCAPE) {
         setVisible(false);
         setFocusItem(0);
-      }
-      if (e.key === KeyboardKeys.TAB) return;
-
-      if (e.key === KeyboardKeys.DOWN && focusedItemIndex < childrenArray.length - 1) {
-        setFocusItem((prev) => prev + 1);
+        menuButtonRef.current.focus();
       }
 
-      if (e.key === KeyboardKeys.UP && focusedItemIndex > 0) {
-        setFocusItem((prev) => prev - 1);
+      if (e.key === KeyboardKeys.DOWN) {
+        setFocusItem((prev) => (prev === childrenArray.length - 1 ? 0 : prev + 1));
+      }
+
+      if (e.key === KeyboardKeys.UP) {
+        setFocusItem((prev) => (prev === 0 ? childrenArray.length - 1 : prev - 1));
       }
     }
   };
@@ -111,9 +111,9 @@ export const SimpleMenu = ({ label, children, ...props }) => {
   };
 
   const handleBlur = (e) => {
-    if (!e.currentTarget.contains(e.relatedTarget)) {
-      setVisible(false);
-    }
+    // if (!e.currentTarget.contains(e.relatedTarget)) {
+    //   setVisible(false);
+    // }
   };
 
   const handleMenuButtonClick = () => {
@@ -123,9 +123,10 @@ export const SimpleMenu = ({ label, children, ...props }) => {
   const childrenClone = childrenArray.map((child, index) =>
     cloneElement(child, {
       onClick: () => {
-        setVisible(false);
-        setFocusItem(0);
         child.props.onClick();
+        // setFocusItem(0);
+        setVisible(false);
+        menuButtonRef.current.focus();
       },
       isFocused: focusedItemIndex === index,
     }),
@@ -137,10 +138,10 @@ export const SimpleMenu = ({ label, children, ...props }) => {
         aria-haspopup
         aria-expanded={visible}
         aria-controls={menuId}
-        {...props}
         onKeyDown={handleKeyDown}
         onMouseDown={handleMenuButtonClick}
         ref={menuButtonRef}
+        {...props}
       >
         <Box paddingRight={1}>
           <TextButton>{label}</TextButton>

--- a/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
+++ b/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
@@ -52,6 +52,12 @@ export const MenuItem = ({ children, onClick, href, isFocused, ...props }) => {
     ...props,
   };
 
+  const handleKeyDown = (e) => {
+    if (e.key === KeyboardKeys.SPACE || e.key === KeyboardKeys.ENTER) {
+      onClick();
+    }
+  };
+
   return (
     <Row as="li" justifyContent="center">
       {href ? (
@@ -61,7 +67,7 @@ export const MenuItem = ({ children, onClick, href, isFocused, ...props }) => {
           </Box>
         </OptionLink>
       ) : (
-        <OptionButton onClick={onClick} {...menuItemProps}>
+        <OptionButton onKeyDown={handleKeyDown} onMouseDown={onClick} {...menuItemProps}>
           <Box padding={2}>
             <Text as="span">{children}</Text>
           </Box>
@@ -108,11 +114,8 @@ export const SimpleMenu = ({ label, children, ...props }) => {
   };
 
   const handleKeyDown = (e) => {
-    switch (e.key) {
-      case KeyboardKeys.SPACE:
-      case KeyboardKeys.ENTER: {
-        setVisible((prevVisible) => !prevVisible);
-      }
+    if (e.key === KeyboardKeys.ENTER || e.key === KeyboardKeys.SPACE) {
+      setVisible((prevVisible) => !prevVisible);
     }
   };
 

--- a/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.stories.mdx
+++ b/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.stories.mdx
@@ -1,0 +1,23 @@
+<!--- SimpleMenu.stories.mdx --->
+
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { SimpleMenu } from './SimpleMenu';
+
+<Meta
+  title="SimpleMenu"
+  component={ SimpleMenu }
+/>
+
+# SimpleMenu
+
+This is the doc of the `SimpleMenu` component
+
+## SimpleMenu
+
+Description...
+
+<Canvas>
+  <Story name="base">
+    <SimpleMenu />
+  </Story>
+</Canvas>

--- a/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.stories.mdx
+++ b/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.stories.mdx
@@ -1,12 +1,10 @@
 <!--- SimpleMenu.stories.mdx --->
 
+import { useState } from 'react';
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
-import { SimpleMenu } from './SimpleMenu';
+import { SimpleMenu, MenuItem } from './SimpleMenu';
 
-<Meta
-  title="SimpleMenu"
-  component={ SimpleMenu }
-/>
+<Meta title="Design System/Atoms/SimpleMenu" component={SimpleMenu} />
 
 # SimpleMenu
 
@@ -18,6 +16,21 @@ Description...
 
 <Canvas>
   <Story name="base">
-    <SimpleMenu />
+    {() => {
+      const [val, setValue] = useState('January');
+      return (
+        <SimpleMenu id="label" label={val}>
+          <MenuItem id="menuItem-January" onClick={() => setValue('January')}>
+            January
+          </MenuItem>
+          <MenuItem id="menuItem-February" onClick={() => setValue('February')}>
+            February
+          </MenuItem>
+          <MenuItem id="menuItem-Strapi" href="https://strapi.io">
+            Strapi website
+          </MenuItem>
+        </SimpleMenu>
+      );
+    }}
   </Story>
 </Canvas>

--- a/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.e2e.js
+++ b/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.e2e.js
@@ -1,0 +1,13 @@
+import { injectAxe, checkA11y } from 'axe-playwright';
+
+describe('SimpleMenu', () => {
+  beforeEach(async () => {
+    // This is the URL of the Storybook Iframe
+    await page.goto('http://localhost:6006/iframe.html?id=simplemenu--base&viewMode=story');
+    await injectAxe(page);
+  });
+
+  it('triggers axe on the document', async () => {
+    await checkA11y(page);
+  });
+});

--- a/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.e2e.js
+++ b/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.e2e.js
@@ -12,10 +12,12 @@ describe('SimpleMenu', () => {
   });
 
   it('select the second value of the menu', async () => {
-    await page.click('text="January"');
-    await page.click('text="February"');
+    await page.focus('button');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
 
-    const label = await page.textContent('#label p');
+    const label = await page.textContent('button');
     expect(label).toBe('February');
   });
 });

--- a/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.e2e.js
+++ b/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.e2e.js
@@ -3,11 +3,19 @@ import { injectAxe, checkA11y } from 'axe-playwright';
 describe('SimpleMenu', () => {
   beforeEach(async () => {
     // This is the URL of the Storybook Iframe
-    await page.goto('http://localhost:6006/iframe.html?id=simplemenu--base&viewMode=story');
+    await page.goto('http://localhost:6006/iframe.html?id=design-system-atoms-simplemenu--base&viewMode=story');
     await injectAxe(page);
   });
 
   it('triggers axe on the document', async () => {
     await checkA11y(page);
+  });
+
+  it('select the second value of the menu', async () => {
+    await page.click('text="January"');
+    await page.click('text="February"');
+
+    const label = await page.textContent('#label p');
+    expect(label).toBe('February');
   });
 });

--- a/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.e2e.js
+++ b/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.e2e.js
@@ -11,11 +11,11 @@ describe('SimpleMenu', () => {
     await checkA11y(page);
   });
 
-  it('select the second value of the menu', async () => {
+  it.each(['Enter', 'Space'])('select the second value of the menu', async (keyPressed) => {
     await page.focus('button');
-    await page.keyboard.press('Enter');
+    await page.keyboard.press(keyPressed);
     await page.keyboard.press('ArrowDown');
-    await page.keyboard.press('Enter');
+    await page.keyboard.press(keyPressed);
 
     const label = await page.textContent('button');
     expect(label).toBe('February');

--- a/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.spec.js
+++ b/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.spec.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
-import { SimpleMenu } from '../SimpleMenu';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SimpleMenu, MenuItem } from '../SimpleMenu';
 import { ThemeProvider } from '../../ThemeProvider';
 import { lightTheme } from '../../themes';
 
@@ -8,10 +8,119 @@ describe('SimpleMenu', () => {
   it('snapshots the component', () => {
     const { container } = render(
       <ThemeProvider theme={lightTheme}>
-        <SimpleMenu />
+        <SimpleMenu label="January">
+          <MenuItem onClick={() => {}}>January</MenuItem>
+          <MenuItem onClick={() => {}}>February</MenuItem>
+          <MenuItem href="https://strapi.io">Strapi website</MenuItem>
+        </SimpleMenu>
       </ThemeProvider>,
     );
 
-    expect(container.firstChild).toMatchInlineSnapshot();
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c2 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+      }
+
+      .c3 {
+        font-weight: 600;
+        line-height: 1.14;
+      }
+
+      .c1 {
+        padding-right: 4px;
+      }
+
+      .c0 {
+        border: none;
+        background: transparent;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+        font-size: 0.75rem;
+      }
+
+      .c0 svg {
+        height: 4px;
+      }
+
+      <div>
+        <button
+          class="c0"
+        >
+          <div
+            class="c1"
+          >
+            <p
+              class="c2 c3"
+            >
+              January
+            </p>
+          </div>
+          <svg
+            aria-hidden="true"
+            fill="none"
+            height="1em"
+            viewBox="0 0 14 8"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+              fill="#32324D"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+    `);
+  });
+
+  it('display the menu on click on the menu button', async () => {
+    render(
+      <ThemeProvider theme={lightTheme}>
+        <SimpleMenu label="January">
+          <MenuItem onClick={() => {}}>January</MenuItem>
+          <MenuItem onClick={() => {}}>February</MenuItem>
+          <MenuItem href="https://strapi.io">Strapi website</MenuItem>
+        </SimpleMenu>
+      </ThemeProvider>,
+    );
+
+    const button = await waitFor(() => screen.getByText('January'));
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText('February')).toBeInTheDocument();
+    });
+  });
+
+  it('display the menu and click on a menu item', async () => {
+    const onClickSpy = jest.fn();
+
+    render(
+      <ThemeProvider theme={lightTheme}>
+        <SimpleMenu label="January">
+          <MenuItem onClick={onClickSpy}>January</MenuItem>
+          <MenuItem onClick={onClickSpy}>February</MenuItem>
+          <MenuItem href="https://strapi.io">Strapi website</MenuItem>
+        </SimpleMenu>
+      </ThemeProvider>,
+    );
+
+    const button = await waitFor(() => screen.getByText('January'));
+    fireEvent.click(button);
+
+    const menuItemButton = await waitFor(() => screen.getByText('February'));
+    fireEvent.click(menuItemButton);
+
+    expect(onClickSpy).toBeCalled();
   });
 });

--- a/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.spec.js
+++ b/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.spec.js
@@ -4,6 +4,10 @@ import { SimpleMenu, MenuItem } from '../SimpleMenu';
 import { ThemeProvider } from '../../ThemeProvider';
 import { lightTheme } from '../../themes';
 
+jest.mock('uuid', () => ({
+  v4: () => 1,
+}));
+
 describe('SimpleMenu', () => {
   it('snapshots the component', () => {
     const { container } = render(
@@ -52,6 +56,9 @@ describe('SimpleMenu', () => {
 
       <div>
         <button
+          aria-controls="simpleMenu-1"
+          aria-expanded="false"
+          aria-haspopup="true"
           class="c0"
         >
           <div
@@ -95,7 +102,7 @@ describe('SimpleMenu', () => {
     );
 
     const button = await waitFor(() => screen.getByText('January'));
-    fireEvent.click(button);
+    fireEvent.mouseDown(button);
 
     await waitFor(() => {
       expect(screen.getByText('February')).toBeInTheDocument();
@@ -116,7 +123,7 @@ describe('SimpleMenu', () => {
     );
 
     const button = await waitFor(() => screen.getByText('January'));
-    fireEvent.click(button);
+    fireEvent.mouseDown(button);
 
     const menuItemButton = await waitFor(() => screen.getByText('February'));
     fireEvent.click(menuItemButton);

--- a/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.spec.js
+++ b/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.spec.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { SimpleMenu } from '../SimpleMenu';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+
+describe('SimpleMenu', () => {
+  it('snapshots the component', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <SimpleMenu />
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot();
+  });
+});

--- a/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.spec.js
+++ b/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.spec.js
@@ -130,7 +130,7 @@ describe('SimpleMenu', () => {
     fireEvent.mouseDown(button);
 
     const menuItemButton = await waitFor(() => screen.getByText('February'));
-    fireEvent.click(menuItemButton);
+    fireEvent.mouseDown(menuItemButton);
 
     expect(onClickSpy).toBeCalled();
   });

--- a/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.spec.js
+++ b/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.spec.js
@@ -51,7 +51,11 @@ describe('SimpleMenu', () => {
       }
 
       .c0 svg {
-        height: 4px;
+        height: 0.25rem;
+      }
+
+      .c0 svg path {
+        fill: #8e8ea9;
       }
 
       <div>
@@ -64,11 +68,11 @@ describe('SimpleMenu', () => {
           <div
             class="c1"
           >
-            <p
+            <span
               class="c2 c3"
             >
               January
-            </p>
+            </span>
           </div>
           <svg
             aria-hidden="true"

--- a/packages/strapi-design-system/src/SimpleMenu/index.js
+++ b/packages/strapi-design-system/src/SimpleMenu/index.js
@@ -1,0 +1,1 @@
+export * from './SimpleMenu';

--- a/packages/strapi-design-system/src/SimpleMenu/utils.js
+++ b/packages/strapi-design-system/src/SimpleMenu/utils.js
@@ -1,0 +1,12 @@
+export const getOptionStyle = ({ theme }) => `
+    text-align: left;
+    width: 100%;
+    color: ${theme.colors.neutral800};
+    border-radius: ${theme.borderRadius};
+    &:focus {
+        background-color: ${theme.colors.primary100};
+    }
+    &:hover {
+        background-color: ${theme.colors.primary100};
+    }
+`;


### PR DESCRIPTION
# Simple menu

## Description
Add the simple menu dropdown.

## Demo
Example on : https://design-system-git-simple-menu-strapijs.vercel.app/?path=/story/design-system-atoms-simplemenu--base

## API

```jsx
<SimpleMenu label="January">
   <MenuItem id="menuItem-January" onClick={() => setValue('January')}>
     January
   </MenuItem>
   <MenuItem id="menuItem-February" onClick={() => setValue('February')}>
     February
   </MenuItem>
   <MenuItem id="menuItem-Strapi" href="https://strapi.io">
     Strapi website
   </MenuItem>
 </SimpleMenu>
```

## Voiceover

![simplemenu](https://user-images.githubusercontent.com/7756284/120812892-b3862a00-c54d-11eb-929a-dce9af426437.gif)