### PR TITLE
Add a Select component

### DIFF
--- a/packages/strapi-design-system/.eslintrc.js
+++ b/packages/strapi-design-system/.eslintrc.js
@@ -17,5 +17,6 @@ module.exports = {
   ],
   rules: {
     'react/sort-prop-types': 1,
+    'default-case': 'error',
   },
 };

--- a/packages/strapi-design-system/package.json
+++ b/packages/strapi-design-system/package.json
@@ -28,7 +28,7 @@
     "jest": "^26.6.3",
     "jest-playwright-preset": "^1.5.2",
     "jest-styled-components": "^7.0.4",
-    "playwright": "^1.10.0",
+    "playwright": "^1.11.1",
     "prettier": "^2.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/packages/strapi-design-system/src/Field/Field.js
+++ b/packages/strapi-design-system/src/Field/Field.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import { genId } from '../helpers/genId';
 import { FieldContext } from './FieldContext';
 
-export const Field = ({ children, name, error, hint, id }) => {
+export const Field = ({ children, name, error, hint, id, ...props }) => {
   const idRef = useRef(id || genId());
 
   return (
-    <div>
+    <div {...props}>
       <FieldContext.Provider value={{ name, id: idRef.current, error, hint }}>{children}</FieldContext.Provider>
     </div>
   );
@@ -17,12 +17,13 @@ Field.defaultProps = {
   error: undefined,
   hint: undefined,
   id: undefined,
+  name: undefined,
 };
 
 Field.propTypes = {
   children: PropTypes.node.isRequired,
   error: PropTypes.string,
   hint: PropTypes.string,
-  id: PropTypes.string,
-  name: PropTypes.string.isRequired,
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  name: PropTypes.string,
 };

--- a/packages/strapi-design-system/src/Field/FieldLabel.js
+++ b/packages/strapi-design-system/src/Field/FieldLabel.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import { useField } from './FieldContext';
 import { Text } from '../Text';
 
-export const FieldLabel = ({ children }) => {
+export const FieldLabel = ({ children, ...props }) => {
   const { id } = useField();
 
   const fieldId = `field-${id}`;
 
   return (
-    <Text textColor="neutral800" htmlFor={fieldId} small={true} highlighted={true} as="label">
+    <Text textColor="neutral800" htmlFor={fieldId} small={true} highlighted={true} as="label" {...props}>
       {children}
     </Text>
   );

--- a/packages/strapi-design-system/src/Field/FieldLabel.js
+++ b/packages/strapi-design-system/src/Field/FieldLabel.js
@@ -9,7 +9,7 @@ export const FieldLabel = ({ children, ...props }) => {
   const fieldId = `field-${id}`;
 
   return (
-    <Text textColor="neutral800" htmlFor={fieldId} small={true} highlighted={true} as="label" {...props}>
+    <Text textColor="neutral800" htmlFor={fieldId} small highlighted as="label" {...props}>
       {children}
     </Text>
   );

--- a/packages/strapi-design-system/src/Select/Option.js
+++ b/packages/strapi-design-system/src/Select/Option.js
@@ -35,6 +35,9 @@ export const Option = ({ selected, children, onSelect, value, ...props }) => {
         onSelect();
         break;
       }
+
+      default:
+        break;
     }
   };
 

--- a/packages/strapi-design-system/src/Select/Option.js
+++ b/packages/strapi-design-system/src/Select/Option.js
@@ -1,0 +1,75 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Box } from '../Box';
+import { Text } from '../Text';
+import { KeyboardKeys } from '../helpers/keyboardKeys';
+
+const OptionBox = styled(Box)`
+  width: 100%;
+  border: none;
+  text-align: left;
+  outline-offset: -3px;
+
+  &:focus-visible,
+  &:hover {
+    background: ${({ theme }) => theme.colors.primary100};
+  }
+`;
+
+export const Option = ({ selected, children, onSelect, value, ...props }) => {
+  const optionRef = useRef(null);
+
+  useEffect(() => {
+    if (!optionRef.current) return;
+
+    if (selected) {
+      optionRef.current.focus();
+    }
+  }, [selected]);
+
+  const handleKeyDown = (e) => {
+    switch (e.key) {
+      case KeyboardKeys.SPACE:
+      case KeyboardKeys.ENTER: {
+        onSelect();
+        break;
+      }
+    }
+  };
+
+  return (
+    <OptionBox
+      as="li"
+      hasRadius
+      paddingLeft={4}
+      paddingRight={4}
+      paddingTop={2}
+      paddingBottom={2}
+      ref={optionRef}
+      role="option"
+      aria-selected={selected}
+      tabIndex={selected ? 0 : -1}
+      background={'neutral0'}
+      onKeyDown={handleKeyDown}
+      onClick={onSelect}
+      {...props}
+    >
+      <Text as="span" textColor={selected ? 'primary600' : 'neutral800'} highlighted={selected}>
+        {children}
+      </Text>
+    </OptionBox>
+  );
+};
+
+Option.defaultProps = {
+  selected: false,
+  onSelect: () => undefined,
+};
+
+Option.propTypes = {
+  children: PropTypes.string.isRequired,
+  onSelect: PropTypes.func,
+  selected: PropTypes.bool,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};

--- a/packages/strapi-design-system/src/Select/Select.js
+++ b/packages/strapi-design-system/src/Select/Select.js
@@ -38,7 +38,8 @@ export const Select = ({
     setExpanded((s) => !s);
 
     /**
-     * Make sure the focus is sent when React has finished its rendering phase
+     * the ref from the "ul" element is only known when "expanded" is true AND that react has batched the DOM with the according modifications
+     * we also know that react batches stuff every ~16ms, so pushing stuff in a macro-task makes sure React finishes before calling the callback
      */
     setTimeout(() => {
       if (!listRef.current) return;

--- a/packages/strapi-design-system/src/Select/Select.js
+++ b/packages/strapi-design-system/src/Select/Select.js
@@ -1,0 +1,196 @@
+import React, { Children, cloneElement, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import DropdownIcon from '@strapi/icons/FilterDropdownIcon';
+import CloseAlertIcon from '@strapi/icons/CloseAlertIcon';
+import { SelectButton } from './SelectButton';
+import { Field, FieldHint, FieldLabel, FieldError } from '../Field';
+import { Popover } from '../Popover';
+import { Stack } from '../Stack';
+import { Text } from '../Text';
+import { Row } from '../Row';
+import { genId } from '../helpers/genId';
+import { SelectList } from './SelectList';
+import { SelectButtonWrapper, IconBox, CaretBox } from './components';
+
+export const Select = ({
+  label,
+  id,
+  children,
+  placeholder,
+  onChange,
+  value,
+  hint,
+  error,
+  disabled,
+  clearLabel,
+  ...props
+}) => {
+  const idRef = useRef(id || genId());
+  const listRef = useRef(null);
+  const buttonRef = useRef(null);
+  const containerRef = useRef(null);
+  const [expanded, setExpanded] = useState(false);
+
+  const labelId = `label-${idRef.current}`;
+  const contentId = `content-${idRef.current}`;
+
+  const handleTrigger = (direction = 'down') => {
+    setExpanded((s) => !s);
+
+    /**
+     * Make sure the focus is sent when React has finished its rendering phase
+     */
+    setTimeout(() => {
+      if (!listRef.current) return;
+
+      const lastSelected = listRef.current.querySelector('[aria-selected="true"]');
+      const options = listRef.current.querySelectorAll('[role="option"]');
+
+      if (direction === 'up') {
+        const lastOption = lastSelected || options[options.length - 1];
+
+        if (lastOption) {
+          lastOption.focus();
+        }
+      } else {
+        const firstOption = lastSelected || options[0];
+
+        if (firstOption) {
+          firstOption.focus();
+        }
+      }
+    }, 0);
+  };
+
+  const handleEscape = () => {
+    setExpanded(false);
+
+    buttonRef.current.focus();
+  };
+
+  const handleClear = () => {
+    if (disabled) return;
+
+    onChange(undefined);
+    buttonRef.current.focus();
+  };
+
+  const handleMouseDown = (e) => {
+    if (disabled) return;
+    // Check if the right click has been clicked
+    // "which" check is for webkit
+    if (e.nativeEvent.which === 3 || e.nativeEvent.button === 2) {
+      return;
+    }
+
+    handleTrigger();
+  };
+
+  let selectOptionLabel;
+  let activeOptionId;
+
+  const childrenClone = Children.toArray(children).map((node) => {
+    const optionId = `option-${idRef.current}-${node.props.value}`;
+
+    const handleChange = () => {
+      onChange(node.props.value);
+      setExpanded(false);
+      buttonRef.current.focus();
+    };
+
+    const selected = node.props.value === value;
+
+    if (selected) {
+      selectOptionLabel = node.props.children;
+      activeOptionId = optionId;
+    }
+
+    return cloneElement(node, {
+      id: optionId,
+      onSelect: handleChange,
+      selected,
+    });
+  });
+
+  return (
+    <Field hint={hint} error={error} id={idRef.current}>
+      <Stack size={1}>
+        <FieldLabel as="span" id={labelId}>
+          {label}
+        </FieldLabel>
+
+        <SelectButtonWrapper hasError={Boolean(error)} disabled={disabled} ref={containerRef}>
+          <Row justifyContent="space-between" as="span">
+            <SelectButton
+              ref={buttonRef}
+              labelledBy={selectOptionLabel ? `${labelId} ${contentId}` : labelId}
+              expanded={expanded}
+              onTrigger={handleTrigger}
+              id={idRef.current}
+              hasError={Boolean(error)}
+              disabled={disabled}
+              onMouseDown={handleMouseDown}
+              {...props}
+            >
+              <Text id={contentId} as="span" aria-hidden={true} textColor={value ? 'neutral800' : 'neutral600'}>
+                {selectOptionLabel || placeholder}
+              </Text>
+            </SelectButton>
+
+            <Row>
+              {value && (
+                <IconBox as="button" onClick={handleClear} aria-label={clearLabel} aria-disabled={disabled}>
+                  <CloseAlertIcon />
+                </IconBox>
+              )}
+
+              <CaretBox paddingLeft={3} aria-hidden as="button" onMouseDown={handleMouseDown} tabIndex={-1}>
+                <DropdownIcon />
+              </CaretBox>
+            </Row>
+          </Row>
+        </SelectButtonWrapper>
+
+        <FieldHint />
+        <FieldError />
+      </Stack>
+
+      {expanded && (
+        <Popover source={containerRef} spacingTop={1} fullWidth>
+          <SelectList
+            selectId={idRef.current}
+            selectedOptionId={activeOptionId}
+            labelledBy={labelId}
+            ref={listRef}
+            onEscape={handleEscape}
+          >
+            {childrenClone}
+          </SelectList>
+        </Popover>
+      )}
+    </Field>
+  );
+};
+
+Select.defaultProps = {
+  children: [],
+  disabled: false,
+  id: undefined,
+  placeholder: undefined,
+  value: undefined,
+  hint: undefined,
+  error: undefined,
+};
+
+Select.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.node),
+  clearLabel: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  error: PropTypes.string,
+  hint: PropTypes.string,
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  label: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  placeholder: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};

--- a/packages/strapi-design-system/src/Select/Select.stories.mdx
+++ b/packages/strapi-design-system/src/Select/Select.stories.mdx
@@ -1,0 +1,49 @@
+<!--- Select.stories.mdx --->
+
+import { useState } from 'react';
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Select } from './Select';
+import { Option } from './Option';
+import { Stack } from '../Stack';
+
+<Meta title="Select" component={Select} />
+
+# Select
+
+This is the doc of the `Select` component
+
+## Select
+
+Description...
+
+<Canvas>
+  <Story name="base">
+    {() => {
+      const [value, setValue] = useState();
+      const [error, toggleError] = useState();
+      const [disabled, toggleDisabled] = useState();
+      return (
+        <Stack size={11}>
+          <h2>Current value is {value}</h2>
+          <Select
+            id="select1"
+            label="Choose your meal"
+            placeholder="Your example"
+            hint="Description line"
+            clearLabel="Clear the meal"
+            error={error}
+            value={value}
+            onChange={setValue}
+            disabled={disabled}
+          >
+            <Option value={'pizza'}>Pizza</Option>
+            <Option value={'hamburger'}>Hamburger</Option>
+            <Option value={'bagel'}>Bagel</Option>
+          </Select>
+          <button onClick={() => toggleError((s) => (s ? undefined : 'An error occured'))}>Show the error state</button>
+          <button onClick={() => toggleDisabled((s) => !s)}>Show the disabled state</button>
+        </Stack>
+      );
+    }}
+  </Story>
+</Canvas>

--- a/packages/strapi-design-system/src/Select/SelectButton.js
+++ b/packages/strapi-design-system/src/Select/SelectButton.js
@@ -1,0 +1,70 @@
+import React, { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { KeyboardKeys } from '../helpers/keyboardKeys';
+
+const StyledSelectButton = styled.button`
+  text-align: left;
+  border: none;
+  padding-left: ${({ theme, hasLeftAction }) => (hasLeftAction ? 0 : theme.spaces[4])};
+  padding-right: ${({ theme, hasRightAction }) => (hasRightAction ? 0 : theme.spaces[4])};
+  padding-top: ${({ theme }) => `${theme.spaces[3]}`};
+  padding-bottom: ${({ theme }) => `${theme.spaces[3]}`};
+  display: block;
+  width: 100%;
+  background: transparent;
+
+  // The focus state is moved to the parent thanks to :focus-within
+  &:focus {
+    outline: none;
+  }
+`;
+
+export const SelectButton = forwardRef(({ children, labelledBy, expanded, onTrigger, disabled, ...props }, ref) => {
+  const handleKeyDown = (e) => {
+    if (disabled) return;
+
+    switch (e.key) {
+      case KeyboardKeys.DOWN:
+      case KeyboardKeys.SPACE:
+      case KeyboardKeys.ENTER: {
+        onTrigger();
+        break;
+      }
+
+      case KeyboardKeys.UP: {
+        onTrigger('up');
+        break;
+      }
+    }
+  };
+
+  return (
+    <StyledSelectButton
+      ref={ref}
+      aria-labelledby={labelledBy}
+      aria-haspopup="listbox"
+      aria-expanded={expanded}
+      onKeyDown={handleKeyDown}
+      aria-disabled={disabled}
+      {...props}
+    >
+      {children}
+    </StyledSelectButton>
+  );
+});
+
+SelectButton.displayName = 'SelectButton';
+
+SelectButton.defaultProps = {
+  expanded: false,
+  disabled: false,
+};
+
+SelectButton.propTypes = {
+  children: PropTypes.node.isRequired,
+  disabled: PropTypes.bool,
+  expanded: PropTypes.bool,
+  labelledBy: PropTypes.string.isRequired,
+  onTrigger: PropTypes.func.isRequired,
+};

--- a/packages/strapi-design-system/src/Select/SelectButton.js
+++ b/packages/strapi-design-system/src/Select/SelectButton.js
@@ -36,6 +36,9 @@ export const SelectButton = forwardRef(({ children, labelledBy, expanded, onTrig
         onTrigger('up');
         break;
       }
+
+      default:
+        break;
     }
   };
 

--- a/packages/strapi-design-system/src/Select/SelectList.js
+++ b/packages/strapi-design-system/src/Select/SelectList.js
@@ -1,0 +1,71 @@
+import React, { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+import { KeyboardKeys } from '../helpers/keyboardKeys';
+
+export const SelectList = forwardRef(({ labelledBy, selectedOptionId, children, onEscape }, ref) => {
+  const handleKeyDown = (e) => {
+    switch (e.key) {
+      case KeyboardKeys.ESCAPE: {
+        onEscape();
+        break;
+      }
+
+      case KeyboardKeys.DOWN: {
+        const currentOption = document.activeElement;
+        const nextOption = currentOption.nextSibling;
+
+        if (nextOption) {
+          return nextOption.focus();
+        }
+        const options = ref.current.querySelectorAll('[role="option"]');
+        return options[0].focus();
+      }
+
+      case KeyboardKeys.UP: {
+        const currentOption = document.activeElement;
+        const previousOption = currentOption.previousSibling;
+
+        if (previousOption) {
+          return previousOption.focus();
+        }
+        const options = ref.current.querySelectorAll('[role="option"]');
+        return options[options.length - 1].focus();
+      }
+    }
+  };
+
+  const handleBlur = (e) => {
+    const focusTarget = e.relatedTarget;
+
+    if (!focusTarget || focusTarget.getAttribute('role') !== 'option') {
+      onEscape();
+    }
+  };
+
+  return (
+    <ul
+      role="listbox"
+      aria-labelledby={labelledBy}
+      aria-activedescendant={selectedOptionId}
+      tabIndex={-1}
+      ref={ref}
+      onKeyDown={handleKeyDown}
+      onBlur={handleBlur}
+    >
+      {children}
+    </ul>
+  );
+});
+
+SelectList.displayName = 'SelectList';
+
+SelectList.defaultProps = {
+  selectedOptionId: undefined,
+};
+
+SelectList.propTypes = {
+  children: PropTypes.node.isRequired,
+  labelledBy: PropTypes.string.isRequired,
+  onEscape: PropTypes.func.isRequired,
+  selectedOptionId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};

--- a/packages/strapi-design-system/src/Select/SelectList.js
+++ b/packages/strapi-design-system/src/Select/SelectList.js
@@ -31,6 +31,9 @@ export const SelectList = forwardRef(({ labelledBy, selectedOptionId, children, 
         const options = ref.current.querySelectorAll('[role="option"]');
         return options[options.length - 1].focus();
       }
+
+      default:
+        break;
     }
   };
 

--- a/packages/strapi-design-system/src/Select/__tests__/Select.e2e.js
+++ b/packages/strapi-design-system/src/Select/__tests__/Select.e2e.js
@@ -1,0 +1,120 @@
+import { injectAxe, checkA11y } from 'axe-playwright';
+
+describe('Select', () => {
+  beforeEach(async () => {
+    // This is the URL of the Storybook Iframe
+    await page.goto('http://localhost:6006/iframe.html?id=select--base&viewMode=story');
+    await injectAxe(page);
+  });
+
+  it('triggers axe on the document', async () => {
+    await checkA11y(page);
+  });
+
+  it('triggers axe on the document when the popover is opened', async () => {
+    await page.click('text="Choose your meal"');
+    await checkA11y(page);
+  });
+
+  it('triggers axe on the document when the button is disabled', async () => {
+    await page.click('text=Show the disabled state');
+    await checkA11y(page);
+  });
+
+  describe('Keyboard interactions', () => {
+    it.each(['Enter', 'ArrowDown', 'Space'])(
+      'opens the listbox and highlights the first item when pressing %s',
+      async (key) => {
+        await page.focus('#select1');
+        await page.keyboard.press(key);
+        await expect(page).toHaveSelector('[role="listbox"]');
+
+        await expect(page).toHaveFocus('#option-select1-pizza');
+      },
+    );
+
+    it('opens the listbox and highlights the last item when pressing ArrowUp', async () => {
+      await page.focus('#select1');
+      await page.keyboard.press('ArrowUp');
+      await expect(page).toHaveSelector('[role="listbox"]');
+
+      await expect(page).toHaveFocus('#option-select1-bagel');
+    });
+
+    it('opens the listbox and highlights the different items when pressing ArrowDown', async () => {
+      await page.focus('#select1');
+      await page.keyboard.press('ArrowDown');
+      await expect(page).toHaveSelector('[role="listbox"]');
+
+      await expect(page).toHaveFocus('#option-select1-pizza');
+
+      await page.keyboard.press('ArrowDown');
+      await expect(page).toHaveFocus('#option-select1-hamburger');
+
+      await page.keyboard.press('ArrowDown');
+      await expect(page).toHaveFocus('#option-select1-bagel');
+
+      await page.keyboard.press('ArrowDown');
+      await expect(page).toHaveFocus('#option-select1-pizza');
+    });
+
+    it('opens the listbox and highlights the different items when pressing ArrowUp', async () => {
+      await page.focus('#select1');
+      await page.keyboard.press('ArrowUp');
+      await expect(page).toHaveSelector('[role="listbox"]');
+
+      await expect(page).toHaveFocus('#option-select1-bagel');
+
+      await page.keyboard.press('ArrowUp');
+      await expect(page).toHaveFocus('#option-select1-hamburger');
+
+      await page.keyboard.press('ArrowUp');
+      await expect(page).toHaveFocus('#option-select1-pizza');
+
+      await page.keyboard.press('ArrowUp');
+      await expect(page).toHaveFocus('#option-select1-bagel');
+    });
+
+    it('sends back the focus to the select button when pressing escape when the popover is visible', async () => {
+      await page.focus('#select1');
+      await page.keyboard.press('ArrowUp');
+      await expect(page).toHaveSelector('[role="listbox"]');
+
+      await page.keyboard.press('Escape');
+
+      await expect(page).not.toHaveSelector('[role="listbox"]', { timeout: 1000 });
+      await expect(page).toHaveFocus('#select1');
+    });
+
+    it('changes the button content and the select value when pressing Enter on an item', async () => {
+      await page.focus('#select1');
+      await page.keyboard.press('ArrowUp');
+      await expect(page).toHaveSelector('[role="listbox"]');
+
+      await page.keyboard.press('Enter');
+
+      await expect(await page.$('text=Current value is bagel')).toBeTruthy();
+      await expect(page).toHaveText('#select1', 'Bagel');
+    });
+
+    it('focuses the previously selected item when one is selected and the user reopens the popover', async () => {
+      await page.focus('#select1');
+      await page.keyboard.press('ArrowUp');
+      await expect(page).toHaveSelector('[role="listbox"]');
+
+      await page.keyboard.press('Enter');
+      await expect(page).not.toHaveSelector('[role="listbox"]', { timeout: 1000 });
+
+      await page.keyboard.press('Enter');
+      await expect(page).toHaveFocus('#option-select1-bagel');
+    });
+
+    it.each(['Enter', 'Space'])('should not do anything when pressing %s when the element is disabled', async (key) => {
+      await page.click('text=Show the disabled state');
+      await page.focus('#select1');
+      await page.keyboard.press(key);
+
+      await expect(page).not.toHaveSelector('[role="listbox"]', { timeout: 1000 });
+    });
+  });
+});

--- a/packages/strapi-design-system/src/Select/__tests__/Select.spec.js
+++ b/packages/strapi-design-system/src/Select/__tests__/Select.spec.js
@@ -1,0 +1,386 @@
+import * as React from 'react';
+import { fireEvent, screen, render, waitFor } from '@testing-library/react';
+import { Select } from '../Select';
+import { Option } from '../Option';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+
+describe('Select', () => {
+  it('snapshots the component', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Select label="Choose your meal" id={1} onChange={() => {}} clearLabel="Clear the selection">
+          <Option value={'pizza'}>Pizza</Option>
+          <Option value={'hamburger'}>Hamburger</Option>
+          <Option value={'bagel'}>Bagel</Option>
+        </Select>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c4 {
+        text-align: left;
+        border: none;
+        padding-left: 16px;
+        padding-right: 16px;
+        padding-top: 12px;
+        padding-bottom: 12px;
+        display: block;
+        width: 100%;
+        background: transparent;
+      }
+
+      .c4:focus {
+        outline: none;
+      }
+
+      .c1 {
+        font-weight: 500;
+        font-size: 0.75rem;
+        line-height: 1.33;
+        color: #32324d;
+      }
+
+      .c5 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #666687;
+      }
+
+      .c3 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-box-pack: justify;
+        -webkit-justify-content: space-between;
+        -ms-flex-pack: justify;
+        justify-content: space-between;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+      }
+
+      .c6 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+      }
+
+      .c7 {
+        padding-left: 12px;
+      }
+
+      .c0 > * {
+        margin-top: 0;
+        margin-bottom: 0;
+      }
+
+      .c0 > * + * {
+        margin-top: 4px;
+      }
+
+      .c2 {
+        border: 1px solid #dcdce4;
+        padding-right: 12px;
+        border-radius: 4px;
+        background: #ffffff;
+        overflow: hidden;
+      }
+
+      .c2:focus-within {
+        border: 1px solid #4945ff;
+      }
+
+      .c8 {
+        background: transparent;
+        border: none;
+      }
+
+      .c8 svg {
+        height: 0.6875rem;
+        width: 0.6875rem;
+      }
+
+      .c8 svg path {
+        fill: #666687;
+      }
+
+      .c9 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        background: none;
+        border: none;
+      }
+
+      .c9 svg {
+        width: 0.375rem;
+      }
+
+      <div>
+        <div
+          class="c0"
+        >
+          <span
+            class="c1"
+            for="field-1"
+            id="label-1"
+          >
+            Choose your meal
+          </span>
+          <div
+            class="c2"
+          >
+            <span
+              class="c3"
+            >
+              <button
+                aria-disabled="false"
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-labelledby="label-1"
+                class="c4"
+                id="1"
+              >
+                <span
+                  aria-hidden="true"
+                  class="c5"
+                  id="content-1"
+                />
+              </button>
+              <div
+                class="c6"
+              >
+                <button
+                  aria-hidden="true"
+                  class="c7 c8 c9"
+                  tabindex="-1"
+                >
+                  <svg
+                    fill="none"
+                    height="1em"
+                    viewBox="0 0 14 8"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                      fill="#32324D"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </span>
+          </div>
+        </div>
+      </div>
+    `);
+  });
+
+  it('opens the listbox when clicking on the input', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Select label="Choose your meal" id={1} onChange={() => {}} clearLabel="Clear the selection">
+          <Option value={'pizza'}>Pizza</Option>
+          <Option value={'hamburger'}>Hamburger</Option>
+          <Option value={'bagel'}>Bagel</Option>
+        </Select>
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByLabelText('Choose your meal'));
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c4 {
+        text-align: left;
+        border: none;
+        padding-left: 16px;
+        padding-right: 16px;
+        padding-top: 12px;
+        padding-bottom: 12px;
+        display: block;
+        width: 100%;
+        background: transparent;
+      }
+
+      .c4:focus {
+        outline: none;
+      }
+
+      .c1 {
+        font-weight: 500;
+        font-size: 0.75rem;
+        line-height: 1.33;
+        color: #32324d;
+      }
+
+      .c5 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #666687;
+      }
+
+      .c3 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-box-pack: justify;
+        -webkit-justify-content: space-between;
+        -ms-flex-pack: justify;
+        justify-content: space-between;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+      }
+
+      .c6 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+      }
+
+      .c7 {
+        padding-left: 12px;
+      }
+
+      .c0 > * {
+        margin-top: 0;
+        margin-bottom: 0;
+      }
+
+      .c0 > * + * {
+        margin-top: 4px;
+      }
+
+      .c2 {
+        border: 1px solid #dcdce4;
+        padding-right: 12px;
+        border-radius: 4px;
+        background: #ffffff;
+        overflow: hidden;
+      }
+
+      .c2:focus-within {
+        border: 1px solid #4945ff;
+      }
+
+      .c8 {
+        background: transparent;
+        border: none;
+      }
+
+      .c8 svg {
+        height: 0.6875rem;
+        width: 0.6875rem;
+      }
+
+      .c8 svg path {
+        fill: #666687;
+      }
+
+      .c9 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        background: none;
+        border: none;
+      }
+
+      .c9 svg {
+        width: 0.375rem;
+      }
+
+      <div>
+        <div
+          class="c0"
+        >
+          <span
+            class="c1"
+            for="field-1"
+            id="label-1"
+          >
+            Choose your meal
+          </span>
+          <div
+            class="c2"
+          >
+            <span
+              class="c3"
+            >
+              <button
+                aria-disabled="false"
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-labelledby="label-1"
+                class="c4"
+                id="1"
+              >
+                <span
+                  aria-hidden="true"
+                  class="c5"
+                  id="content-1"
+                />
+              </button>
+              <div
+                class="c6"
+              >
+                <button
+                  aria-hidden="true"
+                  class="c7 c8 c9"
+                  tabindex="-1"
+                >
+                  <svg
+                    fill="none"
+                    height="1em"
+                    viewBox="0 0 14 8"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                      fill="#32324D"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </span>
+          </div>
+        </div>
+      </div>
+    `);
+  });
+});

--- a/packages/strapi-design-system/src/Select/components.js
+++ b/packages/strapi-design-system/src/Select/components.js
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+import { Box } from '../Box';
+
+export const SelectButtonWrapper = styled.div`
+  border: 1px solid ${({ theme, hasError }) => (hasError ? theme.colors.danger600 : theme.colors.neutral200)};
+  padding-right: ${({ theme }) => theme.spaces[3]};
+  border-radius: ${({ theme }) => theme.borderRadius};
+  background: ${({ theme }) => theme.colors.neutral0};
+  overflow: hidden;
+
+  ${({ theme, disabled }) =>
+    disabled
+      ? `
+    color: ${theme.colors.neutral600};
+    background: ${theme.colors.neutral150};
+  `
+      : undefined}
+
+  &:focus-within {
+    border: 1px solid ${({ theme }) => theme.colors.primary600};
+  }
+`;
+
+export const IconBox = styled(Box)`
+  background: transparent;
+  border: none;
+
+  svg {
+    height: ${11 / 16}rem;
+    width: ${11 / 16}rem;
+  }
+
+  svg path {
+    fill: ${({ theme }) => theme.colors.neutral600};
+  }
+`;
+
+export const CaretBox = styled(IconBox)`
+  display: flex;
+  background: none;
+  border: none;
+
+  svg {
+    width: ${6 / 16}rem;
+  }
+`;

--- a/packages/strapi-design-system/src/Select/index.js
+++ b/packages/strapi-design-system/src/Select/index.js
@@ -1,0 +1,1 @@
+export * from './Select';

--- a/packages/strapi-design-system/src/Select/index.js
+++ b/packages/strapi-design-system/src/Select/index.js
@@ -1,1 +1,2 @@
 export * from './Select';
+export * from './Option';

--- a/packages/strapi-design-system/yarn.lock
+++ b/packages/strapi-design-system/yarn.lock
@@ -1263,7 +1263,7 @@
     copy-to-clipboard "^3.0.0"
     lit-element "^2.4.0"
 
-"@figspec/react@^0.1.4", "@figspec/react@^0.1.5":
+"@figspec/react@^0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@figspec/react/-/react-0.1.5.tgz#777e67e2bb8dd80ef14d6fd373320d12d27c8e7c"
   integrity sha512-XIVBoj+E3vTWHcAo0Rii6uKtT+wbxRe16Ehj3RURo4BJ0D28eC30KaN7KrG3kQKzBLbuEHyk9215QrgtOo+UMw==
@@ -9132,10 +9132,10 @@ playwright-core@>=1.2.0:
     stack-utils "^2.0.3"
     ws "^7.3.1"
 
-playwright@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.10.0.tgz#a14d295f1ad886caf4cc5e674afe03ac832066bc"
-  integrity sha512-b7SGBcCPq4W3pb4ImEDmNXtO0ZkJbZMuWiShsaNJd+rGfY/6fqwgllsAojmxGSgFmijYw7WxCoPiAIEDIH16Kw==
+playwright@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.11.1.tgz#c5f2946db5195bd099a57ce4e188c01057876cff"
+  integrity sha512-UuMrYuvzttbJXUD7sTVcQBsGRojelGepvuQPD+QtVm/n5zyKvkiUErU/DGRXfX8VDZRdQ5D6qVqZndrydC2b4w==
   dependencies:
     commander "^6.1.0"
     debug "^4.1.1"
@@ -9150,6 +9150,7 @@ playwright@^1.10.0:
     rimraf "^3.0.2"
     stack-utils "^2.0.3"
     ws "^7.3.1"
+    yazl "^2.5.1"
 
 pngjs@^5.0.0:
   version "5.0.0"
@@ -10682,13 +10683,6 @@ store2@^2.12.0:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.12.0.tgz#e1f1b7e1a59b6083b2596a8d067f6ee88fd4d3cf"
   integrity sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==
 
-storybook-addon-designs@^6.0.0-alpha.2:
-  version "6.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/storybook-addon-designs/-/storybook-addon-designs-6.0.0-beta.0.tgz#a710a2a21d493bb6aa2f0042ca11fe3d557a8190"
-  integrity sha512-M//KuSlygyrfsBXVhfZ9qaQqTJx3AaDh4A8aMXXjWbIfbduWkOYDQzOZxGa8itSz6HZhpBH86gS+MDJLuJMeUw==
-  dependencies:
-    "@figspec/react" "^0.1.4"
-
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
@@ -12031,6 +12025,13 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yazl@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
+  integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
+  dependencies:
+    buffer-crc32 "~0.2.3"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
# Select

## Description

Add a `<Select>` component. For now, it's a single value selection (will become a multi in another PR)

## Demo

Example on : https://design-system-git-add-select-strapijs.vercel.app/?path=/story/select--base

## API

```jsx
<Select
  id="select1"
  label="Choose your meal"
  placeholder="Your example"
  hint="Description line"
  clearLabel="Clear the meal"
  error={error}
  value={value}
  onChange={setValue}
  disabled={disabled}
>
  <Option value={'pizza'}>Pizza</Option>
  <Option value={'hamburger'}>Hamburger</Option>
  <Option value={'bagel'}>Bagel</Option>
</Select>
```

## Voiceover

![A user pressing arrow down on the select button and navigating using the arrow down, pressing enter on the "hamburger" item. Then, the user opens the menu again to verify that the active element is "hamburger". Then, the user selects the "clear" icon and assert that the focus is sent back to the select button](https://user-images.githubusercontent.com/3874873/121362329-50720a00-c936-11eb-9f13-d7ac74a73630.gif)
