### PR TITLE
Rework select

### DIFF
--- a/packages/strapi-design-system/src/Select/Option.js
+++ b/packages/strapi-design-system/src/Select/Option.js
@@ -1,9 +1,8 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Box } from '../Box';
 import { Text } from '../Text';
-import { KeyboardKeys } from '../helpers/keyboardKeys';
 
 const OptionBox = styled(Box)`
   width: 100%;
@@ -11,35 +10,17 @@ const OptionBox = styled(Box)`
   text-align: left;
   outline-offset: -3px;
 
-  &:focus-visible,
+  &.is-focused {
+    background: ${({ theme }) => theme.colors.primary100};
+  }
+
   &:hover {
     background: ${({ theme }) => theme.colors.primary100};
   }
 `;
 
-export const Option = ({ selected, children, onSelect, value, ...props }) => {
+export const Option = ({ selected, children, value, ...props }) => {
   const optionRef = useRef(null);
-
-  useEffect(() => {
-    if (!optionRef.current) return;
-
-    if (selected) {
-      optionRef.current.focus();
-    }
-  }, [selected]);
-
-  const handleKeyDown = (e) => {
-    switch (e.key) {
-      case KeyboardKeys.SPACE:
-      case KeyboardKeys.ENTER: {
-        onSelect();
-        break;
-      }
-
-      default:
-        break;
-    }
-  };
 
   return (
     <OptionBox
@@ -52,10 +33,8 @@ export const Option = ({ selected, children, onSelect, value, ...props }) => {
       ref={optionRef}
       role="option"
       aria-selected={selected}
-      tabIndex={selected ? 0 : -1}
       background={'neutral0'}
-      onKeyDown={handleKeyDown}
-      onClick={onSelect}
+      data-strapi-value={value}
       {...props}
     >
       <Text as="span" textColor={selected ? 'primary600' : 'neutral800'} highlighted={selected}>
@@ -67,12 +46,10 @@ export const Option = ({ selected, children, onSelect, value, ...props }) => {
 
 Option.defaultProps = {
   selected: false,
-  onSelect: () => undefined,
 };
 
 Option.propTypes = {
   children: PropTypes.string.isRequired,
-  onSelect: PropTypes.func,
   selected: PropTypes.bool,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
 };

--- a/packages/strapi-design-system/src/Select/SelectButton.js
+++ b/packages/strapi-design-system/src/Select/SelectButton.js
@@ -28,7 +28,7 @@ export const SelectButton = forwardRef(({ children, labelledBy, expanded, onTrig
       case KeyboardKeys.DOWN:
       case KeyboardKeys.SPACE:
       case KeyboardKeys.ENTER: {
-        onTrigger();
+        onTrigger('down');
         break;
       }
 

--- a/packages/strapi-design-system/src/Select/__tests__/Select.e2e.js
+++ b/packages/strapi-design-system/src/Select/__tests__/Select.e2e.js
@@ -1,120 +1,140 @@
 import { injectAxe, checkA11y } from 'axe-playwright';
 
+const getListDescendant = async () =>
+  page.$eval('[role="listbox"]', (node) => node.getAttribute('aria-activedescendant'));
+
 describe('Select', () => {
-  beforeEach(async () => {
-    // This is the URL of the Storybook Iframe
-    await page.goto('http://localhost:6006/iframe.html?id=select--base&viewMode=story');
-    await injectAxe(page);
-  });
+  describe('simple', () => {
+    beforeEach(async () => {
+      // This is the URL of the Storybook Iframe
+      await page.goto('http://localhost:6006/iframe.html?id=select--base&viewMode=story');
+      await injectAxe(page);
+    });
 
-  it('triggers axe on the document', async () => {
-    await checkA11y(page);
-  });
+    it('triggers axe on the document', async () => {
+      await checkA11y(page);
+    });
 
-  it('triggers axe on the document when the popover is opened', async () => {
-    await page.click('text="Choose your meal"');
-    await checkA11y(page);
-  });
+    it('triggers axe on the document when the popover is opened', async () => {
+      await page.click('text="Choose your meal"');
+      await checkA11y(page);
+    });
 
-  it('triggers axe on the document when the button is disabled', async () => {
-    await page.click('text=Show the disabled state');
-    await checkA11y(page);
-  });
+    it('triggers axe on the document when the button is disabled', async () => {
+      await page.click('text=Show the disabled state');
+      await checkA11y(page);
+    });
 
-  describe('Keyboard interactions', () => {
-    it.each(['Enter', 'ArrowDown', 'Space'])(
-      'opens the listbox and highlights the first item when pressing %s',
-      async (key) => {
+    describe('Keyboard interactions', () => {
+      it.each(['Enter', 'ArrowDown', 'Space'])(
+        'opens the listbox and highlights the first item when pressing %s',
+        async (key) => {
+          await page.focus('#select1');
+          await page.keyboard.press(key);
+          await expect(page).toHaveSelector('[role="listbox"]');
+
+          const ariaDescendant = await getListDescendant();
+          await expect(ariaDescendant).toBe('option-select1-pizza');
+        },
+      );
+
+      it('opens the listbox and highlights the last item when pressing ArrowUp', async () => {
         await page.focus('#select1');
-        await page.keyboard.press(key);
+        await page.keyboard.press('ArrowUp');
         await expect(page).toHaveSelector('[role="listbox"]');
 
-        await expect(page).toHaveFocus('#option-select1-pizza');
-      },
-    );
+        const ariaDescendant = await getListDescendant();
+        await expect(ariaDescendant).toBe('option-select1-bagel');
+      });
 
-    it('opens the listbox and highlights the last item when pressing ArrowUp', async () => {
-      await page.focus('#select1');
-      await page.keyboard.press('ArrowUp');
-      await expect(page).toHaveSelector('[role="listbox"]');
+      it('opens the listbox and highlights the different items when pressing ArrowDown', async () => {
+        await page.focus('#select1');
+        await page.keyboard.press('ArrowDown');
+        await expect(page).toHaveSelector('[role="listbox"]');
 
-      await expect(page).toHaveFocus('#option-select1-bagel');
-    });
+        const ariaDescendant1 = await getListDescendant();
+        await expect(ariaDescendant1).toBe('option-select1-pizza');
 
-    it('opens the listbox and highlights the different items when pressing ArrowDown', async () => {
-      await page.focus('#select1');
-      await page.keyboard.press('ArrowDown');
-      await expect(page).toHaveSelector('[role="listbox"]');
+        await page.keyboard.press('ArrowDown');
+        const ariaDescendant2 = await getListDescendant();
+        await expect(ariaDescendant2).toBe('option-select1-hamburger');
 
-      await expect(page).toHaveFocus('#option-select1-pizza');
+        await page.keyboard.press('ArrowDown');
+        const ariaDescendant3 = await getListDescendant();
+        await expect(ariaDescendant3).toBe('option-select1-bagel');
 
-      await page.keyboard.press('ArrowDown');
-      await expect(page).toHaveFocus('#option-select1-hamburger');
+        await page.keyboard.press('ArrowDown');
+        const ariaDescendant4 = await getListDescendant();
+        await expect(ariaDescendant4).toBe('option-select1-pizza');
+      });
 
-      await page.keyboard.press('ArrowDown');
-      await expect(page).toHaveFocus('#option-select1-bagel');
+      it('opens the listbox and highlights the different items when pressing ArrowUp', async () => {
+        await page.focus('#select1');
+        await page.keyboard.press('ArrowUp');
+        await expect(page).toHaveSelector('[role="listbox"]');
 
-      await page.keyboard.press('ArrowDown');
-      await expect(page).toHaveFocus('#option-select1-pizza');
-    });
+        const ariaDescendant1 = await getListDescendant();
+        await expect(ariaDescendant1).toBe('option-select1-bagel');
 
-    it('opens the listbox and highlights the different items when pressing ArrowUp', async () => {
-      await page.focus('#select1');
-      await page.keyboard.press('ArrowUp');
-      await expect(page).toHaveSelector('[role="listbox"]');
+        await page.keyboard.press('ArrowUp');
+        const ariaDescendant2 = await getListDescendant();
+        await expect(ariaDescendant2).toBe('option-select1-hamburger');
 
-      await expect(page).toHaveFocus('#option-select1-bagel');
+        await page.keyboard.press('ArrowUp');
+        const ariaDescendant3 = await getListDescendant();
+        await expect(ariaDescendant3).toBe('option-select1-pizza');
 
-      await page.keyboard.press('ArrowUp');
-      await expect(page).toHaveFocus('#option-select1-hamburger');
+        await page.keyboard.press('ArrowUp');
+        const ariaDescendant4 = await getListDescendant();
+        await expect(ariaDescendant4).toBe('option-select1-bagel');
+      });
 
-      await page.keyboard.press('ArrowUp');
-      await expect(page).toHaveFocus('#option-select1-pizza');
+      it('sends back the focus to the select button when pressing escape when the popover is visible', async () => {
+        await page.focus('#select1');
+        await page.keyboard.press('ArrowUp');
+        await expect(page).toHaveSelector('[role="listbox"]');
 
-      await page.keyboard.press('ArrowUp');
-      await expect(page).toHaveFocus('#option-select1-bagel');
-    });
+        await page.keyboard.press('Escape');
 
-    it('sends back the focus to the select button when pressing escape when the popover is visible', async () => {
-      await page.focus('#select1');
-      await page.keyboard.press('ArrowUp');
-      await expect(page).toHaveSelector('[role="listbox"]');
+        await expect(page).not.toHaveSelector('[role="listbox"]', { timeout: 1000 });
 
-      await page.keyboard.press('Escape');
+        await expect(page).toHaveFocus('#select1');
+      });
 
-      await expect(page).not.toHaveSelector('[role="listbox"]', { timeout: 1000 });
-      await expect(page).toHaveFocus('#select1');
-    });
+      it('changes the button content and the select value when pressing Enter on an item', async () => {
+        await page.focus('#select1');
+        await page.keyboard.press('ArrowUp');
+        await expect(page).toHaveSelector('[role="listbox"]');
 
-    it('changes the button content and the select value when pressing Enter on an item', async () => {
-      await page.focus('#select1');
-      await page.keyboard.press('ArrowUp');
-      await expect(page).toHaveSelector('[role="listbox"]');
+        await page.keyboard.press('Enter');
 
-      await page.keyboard.press('Enter');
+        await expect(await page.$('text=Current value is bagel')).toBeTruthy();
+        await expect(page).toHaveText('#select1', 'Bagel');
+      });
 
-      await expect(await page.$('text=Current value is bagel')).toBeTruthy();
-      await expect(page).toHaveText('#select1', 'Bagel');
-    });
+      it('focuses the previously selected item when one is selected and the user reopens the popover', async () => {
+        await page.focus('#select1');
+        await page.keyboard.press('ArrowUp');
+        await expect(page).toHaveSelector('[role="listbox"]');
 
-    it('focuses the previously selected item when one is selected and the user reopens the popover', async () => {
-      await page.focus('#select1');
-      await page.keyboard.press('ArrowUp');
-      await expect(page).toHaveSelector('[role="listbox"]');
+        await page.keyboard.press('Enter');
+        await expect(page).not.toHaveSelector('[role="listbox"]', { timeout: 1000 });
 
-      await page.keyboard.press('Enter');
-      await expect(page).not.toHaveSelector('[role="listbox"]', { timeout: 1000 });
+        await page.keyboard.press('Enter');
+        const ariaDescendant = await getListDescendant();
+        await expect(ariaDescendant).toBe('option-select1-bagel');
+      });
 
-      await page.keyboard.press('Enter');
-      await expect(page).toHaveFocus('#option-select1-bagel');
-    });
+      it.each(['Enter', 'Space'])(
+        'should not do anything when pressing %s when the element is disabled',
+        async (key) => {
+          await page.click('text=Show the disabled state');
+          await page.focus('#select1');
+          await page.keyboard.press(key);
 
-    it.each(['Enter', 'Space'])('should not do anything when pressing %s when the element is disabled', async (key) => {
-      await page.click('text=Show the disabled state');
-      await page.focus('#select1');
-      await page.keyboard.press(key);
-
-      await expect(page).not.toHaveSelector('[role="listbox"]', { timeout: 1000 });
+          await expect(page).not.toHaveSelector('[role="listbox"]', { timeout: 1000 });
+        },
+      );
     });
   });
 });

--- a/packages/strapi-design-system/src/Select/__tests__/Select.spec.js
+++ b/packages/strapi-design-system/src/Select/__tests__/Select.spec.js
@@ -194,20 +194,32 @@ describe('Select', () => {
     `);
   });
 
-  it('opens the listbox when clicking on the input', () => {
+  it('opens the listbox when clicking on the input', async () => {
     const { container } = render(
       <ThemeProvider theme={lightTheme}>
-        <Select label="Choose your meal" id={1} onChange={() => {}} clearLabel="Clear the selection">
+        <Select
+          id="select1"
+          label="Choose your meal"
+          placeholder="Your example"
+          hint="Description line"
+          clearLabel="Clear the meal"
+          value={'pizza'}
+          onChange={() => {}}
+          disabled={false}
+        >
           <Option value={'pizza'}>Pizza</Option>
           <Option value={'hamburger'}>Hamburger</Option>
           <Option value={'bagel'}>Bagel</Option>
         </Select>
       </ThemeProvider>,
+      { container: document.body },
     );
 
-    fireEvent.click(screen.getByLabelText('Choose your meal'));
+    fireEvent.mouseDown(screen.getByLabelText('Choose your meal'));
 
-    expect(container.firstChild).toMatchInlineSnapshot(`
+    await waitFor(() => container.querySelector('[role="listbox"]'));
+
+    expect(container).toMatchInlineSnapshot(`
       .c4 {
         text-align: left;
         border: none;
@@ -235,7 +247,21 @@ describe('Select', () => {
         font-weight: 400;
         font-size: 0.875rem;
         line-height: 1.43;
+        color: #32324d;
+      }
+
+      .c10 {
+        font-weight: 400;
+        font-size: 0.75rem;
+        line-height: 1.33;
         color: #666687;
+      }
+
+      .c16 {
+        font-weight: 500;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #4945ff;
       }
 
       .c3 {
@@ -270,8 +296,46 @@ describe('Select', () => {
         align-items: center;
       }
 
-      .c7 {
+      .c8 {
         padding-left: 12px;
+      }
+
+      .c11 {
+        background: #ffffff;
+        padding: 4px;
+        border-radius: 4px;
+      }
+
+      .c14 {
+        background: #ffffff;
+        padding-top: 8px;
+        padding-right: 16px;
+        padding-bottom: 8px;
+        padding-left: 16px;
+        border-radius: 4px;
+      }
+
+      .c12 {
+        box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
+        position: absolute;
+        border: 1px solid #eaeaef;
+        background: #ffffff;
+        margin-top: 4px;
+      }
+
+      .c13 {
+        max-height: 15rem;
+        overflow-y: scroll;
+      }
+
+      .c13::-webkit-scrollbar-track {
+        background: #ffffff;
+      }
+
+      .c13::-webkit-scrollbar-thumb {
+        background: #eaeaef;
+        border-radius: 4px;
+        margin-right: 10px;
       }
 
       .c0 > * {
@@ -295,17 +359,17 @@ describe('Select', () => {
         border: 1px solid #4945ff;
       }
 
-      .c8 {
+      .c7 {
         background: transparent;
         border: none;
       }
 
-      .c8 svg {
+      .c7 svg {
         height: 0.6875rem;
         width: 0.6875rem;
       }
 
-      .c8 svg path {
+      .c7 svg path {
         fill: #666687;
       }
 
@@ -322,65 +386,167 @@ describe('Select', () => {
         width: 0.375rem;
       }
 
-      <div>
-        <div
-          class="c0"
-        >
-          <span
-            class="c1"
-            for="field-1"
-            id="label-1"
-          >
-            Choose your meal
-          </span>
+      .c15 {
+        width: 100%;
+        border: none;
+        text-align: left;
+        outline-offset: -3px;
+      }
+
+      .c15.is-focused {
+        background: #f0f0ff;
+      }
+
+      .c15:hover {
+        background: #f0f0ff;
+      }
+
+      <body>
+        <div>
           <div
-            class="c2"
+            class="c0"
           >
             <span
-              class="c3"
+              class="c1"
+              for="field-select1"
+              id="label-select1"
             >
-              <button
-                aria-disabled="false"
-                aria-expanded="false"
-                aria-haspopup="listbox"
-                aria-labelledby="label-1"
-                class="c4"
-                id="1"
-              >
-                <span
-                  aria-hidden="true"
-                  class="c5"
-                  id="content-1"
-                />
-              </button>
-              <div
-                class="c6"
+              Choose your meal
+            </span>
+            <div
+              class="c2"
+            >
+              <span
+                class="c3"
               >
                 <button
-                  aria-hidden="true"
-                  class="c7 c8 c9"
-                  tabindex="-1"
+                  aria-disabled="false"
+                  aria-expanded="true"
+                  aria-haspopup="listbox"
+                  aria-labelledby="label-select1 content-select1"
+                  class="c4"
+                  id="select1"
                 >
-                  <svg
-                    fill="none"
-                    height="1em"
-                    viewBox="0 0 14 8"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
+                  <span
+                    aria-hidden="true"
+                    class="c5"
+                    id="content-select1"
                   >
-                    <path
-                      clip-rule="evenodd"
-                      d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
-                      fill="#32324D"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
+                    Pizza
+                  </span>
                 </button>
-              </div>
-            </span>
+                <div
+                  class="c6"
+                >
+                  <button
+                    aria-disabled="false"
+                    aria-label="Clear the meal"
+                    class="c7"
+                  >
+                    <svg
+                      fill="none"
+                      height="1em"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 2.417L21.583 0 12 9.583 2.417 0 0 2.417 9.583 12 0 21.583 2.417 24 12 14.417 21.583 24 24 21.583 14.417 12 24 2.417z"
+                        fill="#212134"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    aria-hidden="true"
+                    class="c8 c7 c9"
+                    tabindex="-1"
+                  >
+                    <svg
+                      fill="none"
+                      height="1em"
+                      viewBox="0 0 14 8"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                        fill="#32324D"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </span>
+            </div>
+            <p
+              class="c10"
+              id="field-hint-select1"
+            >
+              Description line
+            </p>
           </div>
         </div>
-      </div>
+        <div
+          data-react-portal="true"
+        >
+          <div
+            class="c11 c12"
+            style="left: 0px; top: 0px;"
+          >
+            <div
+              class="c13"
+            >
+              <ul
+                aria-activedescendant="option-select1-pizza"
+                aria-labelledby="label-select1"
+                role="listbox"
+                tabindex="-1"
+              >
+                <li
+                  aria-selected="true"
+                  class="c14 c15 is-focused"
+                  data-strapi-value="pizza"
+                  id="option-select1-pizza"
+                  role="option"
+                >
+                  <span
+                    class="c16"
+                  >
+                    Pizza
+                  </span>
+                </li>
+                <li
+                  aria-selected="false"
+                  class="c14 c15"
+                  data-strapi-value="hamburger"
+                  id="option-select1-hamburger"
+                  role="option"
+                >
+                  <span
+                    class="c5"
+                  >
+                    Hamburger
+                  </span>
+                </li>
+                <li
+                  aria-selected="false"
+                  class="c14 c15"
+                  data-strapi-value="bagel"
+                  id="option-select1-bagel"
+                  role="option"
+                >
+                  <span
+                    class="c5"
+                  >
+                    Bagel
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </body>
     `);
   });
 });

--- a/packages/strapi-design-system/src/Select/hooks/useButtonRef.js
+++ b/packages/strapi-design-system/src/Select/hooks/useButtonRef.js
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from 'react';
+
+export const useButtonRef = (expanded) => {
+  const buttonRef = useRef(null);
+  const mountedRef = useRef(null);
+
+  useEffect(() => {
+    if (!mountedRef.current) return;
+    if (expanded) return;
+
+    buttonRef.current.focus();
+  }, [expanded]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+  }, []);
+
+  return buttonRef;
+};

--- a/packages/strapi-design-system/src/Select/hooks/useListRef.js
+++ b/packages/strapi-design-system/src/Select/hooks/useListRef.js
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+import { changeDescendant } from '../utils';
+
+export const useListRef = (expanded, onSelectItem) => {
+  const listRef = useRef(null);
+
+  useEffect(() => {
+    listRef.current.focus();
+  }, []);
+
+  useEffect(() => {
+    const lastSelected = listRef.current.querySelector('[aria-selected="true"]');
+    const options = listRef.current.querySelectorAll('[role="option"]');
+
+    let nextOption;
+
+    if (lastSelected) {
+      nextOption = lastSelected;
+    } else if (expanded === 'up') {
+      nextOption = options[options.length - 1];
+    } else if (expanded === 'down') {
+      nextOption = options[0];
+    }
+
+    if (nextOption) {
+      changeDescendant(listRef.current, nextOption);
+      onSelectItem(nextOption.getAttribute('data-strapi-value'));
+    }
+  }, [expanded]);
+
+  return listRef;
+};

--- a/packages/strapi-design-system/src/Select/utils.js
+++ b/packages/strapi-design-system/src/Select/utils.js
@@ -1,0 +1,14 @@
+export const changeDescendant = (list, option) => {
+  list.setAttribute('aria-activedescendant', option.getAttribute('id'));
+
+  const options = list.querySelectorAll('[role="option"]');
+
+  options.forEach((opt) => opt.classList.remove('is-focused'));
+  option.classList.add('is-focused');
+};
+
+export const getActiveDescendant = (list) => {
+  const id = list.getAttribute('aria-activedescendant');
+
+  return list.querySelector(`#${id}`);
+};


### PR DESCRIPTION
Reworking the Select component using the `aria-activedescendant` property  https://www.w3.org/TR/wai-aria-practices-1.1/examples/listbox/listbox-collapsible.html

It has a more appropriate semantic, and it will be easier to manager the multi select thing

API stays the same

https://design-system-git-rework-select-strapijs.vercel.app/?path=/story/select--base