### PR TITLE
Select multi tags

### DIFF
--- a/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
+++ b/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
@@ -267,7 +267,7 @@ describe("GenericInput", () => {
 
       expect(container.firstChild).toMatchInlineSnapshot(`
         <div
-          class="sc-kHWWYL klTgTN"
+          class="sc-daBunf jqHNBB"
         >
           <div>
             <div
@@ -285,7 +285,7 @@ describe("GenericInput", () => {
               </div>
               <textarea
                 aria-invalid="false"
-                class="sc-bTDOke kBqnU"
+                class="sc-dsXzNU jtBlXl"
                 id="field-some-id"
                 name="long-content"
               />

--- a/packages/strapi-design-system/src/Popover/Popover.js
+++ b/packages/strapi-design-system/src/Popover/Popover.js
@@ -31,6 +31,11 @@ const PopoverScrollable = styled(Box)`
   max-height: ${3 * 5}rem;
   overflow-y: scroll;
 
+  &::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 4px;
+  }
+
   &::-webkit-scrollbar-track {
     background: ${({ theme }) => theme.colors.neutral0};
   }

--- a/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.js
+++ b/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.js
@@ -42,6 +42,11 @@ describe('Popover', () => {
         overflow-y: scroll;
       }
 
+      .c2::-webkit-scrollbar {
+        -webkit-appearance: none;
+        width: 4px;
+      }
+
       .c2::-webkit-scrollbar-track {
         background: #ffffff;
       }

--- a/packages/strapi-design-system/src/Select/Select.js
+++ b/packages/strapi-design-system/src/Select/Select.js
@@ -138,7 +138,7 @@ export const Select = ({
                 </Box>
               )}
 
-              {withTags && <SelectTags tags={tags} onRemoveTag={onChange} />}
+              {withTags && <SelectTags tags={tags} onRemoveTag={onChange} disabled={disabled} />}
 
               <Box paddingLeft={4} paddingRight={4}>
                 {withTags ? (

--- a/packages/strapi-design-system/src/Select/Select.stories.mdx
+++ b/packages/strapi-design-system/src/Select/Select.stories.mdx
@@ -91,3 +91,52 @@ Description...
     }}
   </Story>
 </Canvas>
+
+## Select multi with tags
+
+Description...
+
+<Canvas>
+  <Story name="multi-withTags">
+    {() => {
+      const [values, setValues] = useState([]);
+      const [error, toggleError] = useState();
+      const [disabled, toggleDisabled] = useState();
+      const onValueChange = (newValue) =>
+        setValues((s) => (s.includes(newValue) ? s.filter((x) => x !== newValue) : [...s, newValue]));
+      return (
+        <Stack size={11}>
+          <h2>Current value is {values.join(', ')}</h2>
+          <Select
+            id="select1"
+            label="Choose your meal"
+            placeholder="Your example"
+            onClear={() => setValues([])}
+            hint="Description line"
+            clearLabel="Clear the meal"
+            error={error}
+            value={values}
+            onChange={onValueChange}
+            disabled={disabled}
+            customizeContent={(values) => `${values.length} currently selected`}
+            multi
+            withTags
+          >
+            <Option value={'pizza'}>Pizza</Option>
+            <Option value={'hamburger'}>Hamburger</Option>
+            <Option value={'bagel'}>Bagel</Option>
+            {Array(20)
+              .fill(null)
+              .map((_, i) => (
+                <Option key={i} value={`${i}`}>
+                  Another option
+                </Option>
+              ))}
+          </Select>
+          <button onClick={() => toggleError((s) => (s ? undefined : 'An error occured'))}>Show the error state</button>
+          <button onClick={() => toggleDisabled((s) => !s)}>Show the disabled state</button>
+        </Stack>
+      );
+    }}
+  </Story>
+</Canvas>

--- a/packages/strapi-design-system/src/Select/SelectButton.js
+++ b/packages/strapi-design-system/src/Select/SelectButton.js
@@ -5,17 +5,14 @@ import { KeyboardKeys } from '../helpers/keyboardKeys';
 import { DownState, UpState } from './constants';
 
 const StyledSelectButton = styled.button`
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans',
-    'Helvetica Neue', sans-serif;
-  text-align: left;
-  border: none;
-  padding-left: ${({ theme, hasLeftAction }) => (hasLeftAction ? 0 : theme.spaces[4])};
-  padding-right: ${({ theme, hasRightAction }) => (hasRightAction ? 0 : theme.spaces[4])};
-  padding-top: ${({ theme }) => `${theme.spaces[3]}`};
-  padding-bottom: ${({ theme }) => `${theme.spaces[3]}`};
-  display: block;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
   width: 100%;
   background: transparent;
+  border: none;
 
   // The focus state is moved to the parent thanks to :focus-within
   &:focus {
@@ -23,7 +20,7 @@ const StyledSelectButton = styled.button`
   }
 `;
 
-export const SelectButton = forwardRef(({ children, labelledBy, expanded, onTrigger, disabled, ...props }, ref) => {
+export const SelectButton = forwardRef(({ labelledBy, expanded, onTrigger, disabled, ...props }, ref) => {
   const handleKeyDown = (e) => {
     if (disabled) return;
 
@@ -56,9 +53,7 @@ export const SelectButton = forwardRef(({ children, labelledBy, expanded, onTrig
       onKeyDown={handleKeyDown}
       aria-disabled={disabled}
       {...props}
-    >
-      {children}
-    </StyledSelectButton>
+    />
   );
 });
 
@@ -70,7 +65,6 @@ SelectButton.defaultProps = {
 };
 
 SelectButton.propTypes = {
-  children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
   expanded: PropTypes.bool,
   labelledBy: PropTypes.string.isRequired,

--- a/packages/strapi-design-system/src/Select/SelectList.js
+++ b/packages/strapi-design-system/src/Select/SelectList.js
@@ -19,6 +19,8 @@ export const SelectList = ({ labelledBy, onSelectItem, children, multi, onEscape
       case KeyboardKeys.DOWN: {
         e.preventDefault();
         const currentOption = getActiveDescendant(listRef.current);
+        if (!currentOption) return;
+
         const nextOption = currentOption.nextSibling;
 
         if (nextOption) {
@@ -43,6 +45,8 @@ export const SelectList = ({ labelledBy, onSelectItem, children, multi, onEscape
       case KeyboardKeys.UP: {
         e.preventDefault();
         const currentOption = getActiveDescendant(listRef.current);
+        if (!currentOption) return;
+
         const previousOption = currentOption.previousSibling;
 
         if (previousOption) {

--- a/packages/strapi-design-system/src/Select/SelectTags.js
+++ b/packages/strapi-design-system/src/Select/SelectTags.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import CloseIcon from '@strapi/icons/CloseAlertIcon';
+import styled from 'styled-components';
+import { Tag } from '../Tag';
+import { Row } from '../Row';
+
+const SelectTagsWrapper = styled.div`
+  margin-bottom: ${({ theme }) => theme.spaces[1]};
+`;
+
+const SelectTag = styled(Tag)`
+  position: relative;
+  z-index: 1;
+  margin-left: ${({ theme }) => theme.spaces[1]};
+  margin-top: ${({ theme }) => theme.spaces[1]};
+`;
+
+export const SelectTags = ({ tags, onRemoveTag }) => {
+  return (
+    <SelectTagsWrapper>
+      <Row wrap="wrap">
+        {tags.map((tag) => (
+          <SelectTag icon={<CloseIcon />} onClick={() => onRemoveTag(tag.value)} tabIndex={-1} key={`tag-${tag.value}`}>
+            {tag.label}
+          </SelectTag>
+        ))}
+      </Row>
+    </SelectTagsWrapper>
+  );
+};
+
+SelectTags.defaultProps = {
+  tags: [],
+};
+
+SelectTags.propTypes = {
+  onRemoveTag: PropTypes.func.isRequired,
+  tags: PropTypes.arrayOf(
+    PropTypes.shape({ label: PropTypes.string, value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]) }),
+  ),
+};

--- a/packages/strapi-design-system/src/Select/SelectTags.js
+++ b/packages/strapi-design-system/src/Select/SelectTags.js
@@ -16,12 +16,24 @@ const SelectTag = styled(Tag)`
   margin-top: ${({ theme }) => theme.spaces[1]};
 `;
 
-export const SelectTags = ({ tags, onRemoveTag }) => {
+export const SelectTags = ({ tags, onRemoveTag, disabled }) => {
+  const handleClick = (value) => {
+    if (disabled) return;
+
+    onRemoveTag(value);
+  };
+
   return (
     <SelectTagsWrapper>
       <Row wrap="wrap">
         {tags.map((tag) => (
-          <SelectTag icon={<CloseIcon />} onClick={() => onRemoveTag(tag.value)} tabIndex={-1} key={`tag-${tag.value}`}>
+          <SelectTag
+            icon={<CloseIcon />}
+            aria-disabled={disabled}
+            onClick={() => handleClick(tag.value)}
+            tabIndex={-1}
+            key={`tag-${tag.value}`}
+          >
             {tag.label}
           </SelectTag>
         ))}
@@ -31,10 +43,12 @@ export const SelectTags = ({ tags, onRemoveTag }) => {
 };
 
 SelectTags.defaultProps = {
+  disabled: false,
   tags: [],
 };
 
 SelectTags.propTypes = {
+  disabled: PropTypes.bool,
   onRemoveTag: PropTypes.func.isRequired,
   tags: PropTypes.arrayOf(
     PropTypes.shape({ label: PropTypes.string, value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]) }),

--- a/packages/strapi-design-system/src/Select/__tests__/Select.e2e.js
+++ b/packages/strapi-design-system/src/Select/__tests__/Select.e2e.js
@@ -103,7 +103,7 @@ describe('Select', () => {
         await page.keyboard.press('Enter');
 
         await expect(await page.$('text=Current value is bagel')).toBeTruthy();
-        await expect(page).toHaveText('#select1', 'Bagel');
+        await expect(page).toHaveText('#content-select1', 'Bagel');
       });
 
       it('focuses the previously selected item when one is selected and the user reopens the popover', async () => {
@@ -135,7 +135,7 @@ describe('Select', () => {
       await page.click('text="Hamburger"');
 
       await page.click('[aria-label="Clear the meal"]');
-      await expect(page).toHaveText('#select1', 'Your example');
+      await expect(page).toHaveText('#content-select1', 'Your example');
     });
   });
 
@@ -146,15 +146,18 @@ describe('Select', () => {
     });
 
     it('selects one value after the other when using the mouse and clears the selected values', async () => {
-      await page.click('text="0 currently selected"');
+      await page.click('#select1');
+
+      await expect(page).toHaveSelector('[role="listbox"]', { timeout: 1000 });
+
       await page.click('text="Hamburger"');
       await page.click('text="Pizza"');
 
+      await expect(page).toHaveText('#content-select1', '2 currently selected');
       await expect(page).toHaveText('h2', 'Current value is hamburger, pizza');
-      await page.click('text="2 currently selected"');
 
       await page.click('[aria-label="Clear the meal"]');
-      await expect(page).toHaveText('#select1', '0 currently selected');
+      await expect(page).toHaveText('#content-select1', '0 currently selected');
     });
 
     describe('keyboard interactions', () => {
@@ -166,7 +169,7 @@ describe('Select', () => {
         await page.keyboard.press('Enter');
 
         await expect(page).toHaveText('h2', 'Current value is pizza, hamburger');
-        await expect(page).toHaveText('#select1', '2 currently selected');
+        await expect(page).toHaveText('#content-select1', '2 currently selected');
       });
 
       it('focuses the previously (first) selected item when one is selected and the user reopens the popover', async () => {

--- a/packages/strapi-design-system/src/Select/__tests__/Select.spec.js
+++ b/packages/strapi-design-system/src/Select/__tests__/Select.spec.js
@@ -365,6 +365,11 @@ describe('Select', () => {
         overflow-y: scroll;
       }
 
+      .c15::-webkit-scrollbar {
+        -webkit-appearance: none;
+        width: 4px;
+      }
+
       .c15::-webkit-scrollbar-track {
         background: #ffffff;
       }
@@ -539,7 +544,6 @@ describe('Select', () => {
               class="c15"
             >
               <ul
-                aria-activedescendant="option-select1-pizza"
                 aria-labelledby="label-select1"
                 aria-multiselectable="false"
                 class="c0"
@@ -548,7 +552,7 @@ describe('Select', () => {
               >
                 <li
                   aria-selected="true"
-                  class="c16 c17 is-focused"
+                  class="c16 c17"
                   data-strapi-value="pizza"
                   id="option-select1-pizza"
                   role="option"
@@ -916,6 +920,11 @@ describe('Select', () => {
         overflow-y: scroll;
       }
 
+      .c2::-webkit-scrollbar {
+        -webkit-appearance: none;
+        width: 4px;
+      }
+
       .c2::-webkit-scrollbar-track {
         background: #ffffff;
       }
@@ -999,7 +1008,6 @@ describe('Select', () => {
               class="c2"
             >
               <ul
-                aria-activedescendant="option-select1-pizza"
                 aria-labelledby="label-select1"
                 aria-multiselectable="true"
                 class="c3"
@@ -1008,7 +1016,7 @@ describe('Select', () => {
               >
                 <li
                   aria-selected="true"
-                  class="c4 c5 is-focused"
+                  class="c4 c5"
                   data-strapi-value="pizza"
                   id="option-select1-pizza"
                   role="option"

--- a/packages/strapi-design-system/src/Select/__tests__/Select.spec.js
+++ b/packages/strapi-design-system/src/Select/__tests__/Select.spec.js
@@ -31,20 +31,18 @@ describe('Select', () => {
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
-      .c4 {
-        font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans', 'Helvetica Neue',sans-serif;
-        text-align: left;
-        border: none;
-        padding-left: 16px;
-        padding-right: 16px;
-        padding-top: 12px;
-        padding-bottom: 12px;
-        display: block;
+      .c3 {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        top: 0;
         width: 100%;
         background: transparent;
+        border: none;
       }
 
-      .c4:focus {
+      .c3:focus {
         outline: none;
       }
 
@@ -55,14 +53,14 @@ describe('Select', () => {
         color: #32324d;
       }
 
-      .c5 {
+      .c8 {
         font-weight: 400;
         font-size: 0.875rem;
         line-height: 1.43;
         color: #666687;
       }
 
-      .c3 {
+      .c4 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -95,6 +93,11 @@ describe('Select', () => {
       }
 
       .c7 {
+        padding-right: 16px;
+        padding-left: 16px;
+      }
+
+      .c9 {
         padding-left: 12px;
       }
 
@@ -108,6 +111,7 @@ describe('Select', () => {
       }
 
       .c2 {
+        position: relative;
         border: 1px solid #dcdce4;
         padding-right: 12px;
         border-radius: 4px;
@@ -119,21 +123,23 @@ describe('Select', () => {
         border: 1px solid #4945ff;
       }
 
-      .c8 {
+      .c10 {
         background: transparent;
         border: none;
+        position: relative;
+        z-index: 1;
       }
 
-      .c8 svg {
+      .c10 svg {
         height: 0.6875rem;
         width: 0.6875rem;
       }
 
-      .c8 svg path {
+      .c10 svg path {
         fill: #666687;
       }
 
-      .c9 {
+      .c11 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -142,8 +148,12 @@ describe('Select', () => {
         border: none;
       }
 
-      .c9 svg {
+      .c11 svg {
         width: 0.375rem;
+      }
+
+      .c5 {
+        min-height: 2.5rem;
       }
 
       <div>
@@ -160,31 +170,37 @@ describe('Select', () => {
           <div
             class="c2"
           >
-            <span
+            <button
+              aria-disabled="false"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="label-1 content-1"
               class="c3"
+              id="1"
+            />
+            <div
+              class="c4 c5"
             >
-              <button
-                aria-disabled="false"
-                aria-expanded="false"
-                aria-haspopup="listbox"
-                aria-labelledby="label-1"
-                class="c4"
-                id="1"
+              <div
+                class="c6"
               >
-                <span
-                  aria-hidden="true"
-                  class="c5"
-                  id="content-1"
+                <div
+                  class="c7"
                 >
-                  Placeholder
-                </span>
-              </button>
+                  <span
+                    class="c8"
+                    id="content-1"
+                  >
+                    Placeholder
+                  </span>
+                </div>
+              </div>
               <div
                 class="c6"
               >
                 <button
                   aria-hidden="true"
-                  class="c7 c8 c9"
+                  class="c9 c10 c11"
                   tabindex="-1"
                 >
                   <svg
@@ -203,7 +219,7 @@ describe('Select', () => {
                   </svg>
                 </button>
               </div>
-            </span>
+            </div>
           </div>
         </div>
       </div>
@@ -237,20 +253,18 @@ describe('Select', () => {
     await waitFor(() => container.querySelector('[role="listbox"]'));
 
     expect(container).toMatchInlineSnapshot(`
-      .c5 {
-        font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans', 'Helvetica Neue',sans-serif;
-        text-align: left;
-        border: none;
-        padding-left: 16px;
-        padding-right: 16px;
-        padding-top: 12px;
-        padding-bottom: 12px;
-        display: block;
+      .c3 {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        top: 0;
         width: 100%;
         background: transparent;
+        border: none;
       }
 
-      .c5:focus {
+      .c3:focus {
         outline: none;
       }
 
@@ -261,28 +275,28 @@ describe('Select', () => {
         color: #32324d;
       }
 
-      .c6 {
+      .c9 {
         font-weight: 400;
         font-size: 0.875rem;
         line-height: 1.43;
         color: #32324d;
       }
 
-      .c10 {
+      .c12 {
         font-weight: 400;
         font-size: 0.75rem;
         line-height: 1.33;
         color: #666687;
       }
 
-      .c16 {
+      .c18 {
         font-weight: 500;
         font-size: 0.875rem;
         line-height: 1.43;
         color: #4945ff;
       }
 
-      .c3 {
+      .c4 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -300,7 +314,7 @@ describe('Select', () => {
         align-items: center;
       }
 
-      .c7 {
+      .c6 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -314,17 +328,22 @@ describe('Select', () => {
         align-items: center;
       }
 
-      .c4 {
+      .c7 {
         padding-left: 12px;
       }
 
-      .c11 {
+      .c8 {
+        padding-right: 16px;
+        padding-left: 16px;
+      }
+
+      .c13 {
         background: #ffffff;
         padding: 4px;
         border-radius: 4px;
       }
 
-      .c14 {
+      .c16 {
         background: #ffffff;
         padding-top: 8px;
         padding-right: 16px;
@@ -333,7 +352,7 @@ describe('Select', () => {
         border-radius: 4px;
       }
 
-      .c12 {
+      .c14 {
         box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
         position: absolute;
         border: 1px solid #eaeaef;
@@ -341,16 +360,16 @@ describe('Select', () => {
         margin-top: 4px;
       }
 
-      .c13 {
+      .c15 {
         max-height: 15rem;
         overflow-y: scroll;
       }
 
-      .c13::-webkit-scrollbar-track {
+      .c15::-webkit-scrollbar-track {
         background: #ffffff;
       }
 
-      .c13::-webkit-scrollbar-thumb {
+      .c15::-webkit-scrollbar-thumb {
         background: #eaeaef;
         border-radius: 4px;
         margin-right: 10px;
@@ -366,6 +385,7 @@ describe('Select', () => {
       }
 
       .c2 {
+        position: relative;
         border: 1px solid #dcdce4;
         padding-right: 12px;
         border-radius: 4px;
@@ -377,21 +397,23 @@ describe('Select', () => {
         border: 1px solid #4945ff;
       }
 
-      .c8 {
+      .c10 {
         background: transparent;
         border: none;
+        position: relative;
+        z-index: 1;
       }
 
-      .c8 svg {
+      .c10 svg {
         height: 0.6875rem;
         width: 0.6875rem;
       }
 
-      .c8 svg path {
+      .c10 svg path {
         fill: #666687;
       }
 
-      .c9 {
+      .c11 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -400,22 +422,26 @@ describe('Select', () => {
         border: none;
       }
 
-      .c9 svg {
+      .c11 svg {
         width: 0.375rem;
       }
 
-      .c15 {
+      .c5 {
+        min-height: 2.5rem;
+      }
+
+      .c17 {
         width: 100%;
         border: none;
         text-align: left;
         outline-offset: -3px;
       }
 
-      .c15.is-focused {
+      .c17.is-focused {
         background: #f0f0ff;
       }
 
-      .c15:hover {
+      .c17:hover {
         background: #f0f0ff;
       }
 
@@ -434,40 +460,46 @@ describe('Select', () => {
             <div
               class="c2"
             >
-              <span
+              <button
+                aria-describedby="field-hint-select1"
+                aria-disabled="false"
+                aria-expanded="true"
+                aria-haspopup="listbox"
+                aria-labelledby="label-select1 content-select1"
                 class="c3"
+                id="select1"
+              />
+              <div
+                class="c4 c5"
               >
                 <div
-                  aria-hidden="true"
-                  class="c4"
+                  class="c6"
                 >
-                  <span>
-                    An icon
-                  </span>
-                </div>
-                <button
-                  aria-describedby="field-hint-select1"
-                  aria-disabled="false"
-                  aria-expanded="true"
-                  aria-haspopup="listbox"
-                  aria-labelledby="label-select1 content-select1"
-                  class="c5"
-                  id="select1"
-                >
-                  <span
+                  <div
                     aria-hidden="true"
-                    class="c6"
-                    id="content-select1"
+                    class="c7"
                   >
-                    Pizza
-                  </span>
-                </button>
+                    <span>
+                      An icon
+                    </span>
+                  </div>
+                  <div
+                    class="c8"
+                  >
+                    <span
+                      class="c9"
+                      id="content-select1"
+                    >
+                      Pizza
+                    </span>
+                  </div>
+                </div>
                 <div
-                  class="c7"
+                  class="c6"
                 >
                   <button
                     aria-hidden="true"
-                    class="c4 c8 c9"
+                    class="c7 c10 c11"
                     tabindex="-1"
                   >
                     <svg
@@ -486,10 +518,10 @@ describe('Select', () => {
                     </svg>
                   </button>
                 </div>
-              </span>
+              </div>
             </div>
             <p
-              class="c10"
+              class="c12"
               id="field-hint-select1"
             >
               Description line
@@ -500,11 +532,11 @@ describe('Select', () => {
           data-react-portal="true"
         >
           <div
-            class="c11 c12"
+            class="c13 c14"
             style="left: 0px; top: 0px;"
           >
             <div
-              class="c13"
+              class="c15"
             >
               <ul
                 aria-activedescendant="option-select1-pizza"
@@ -516,16 +548,16 @@ describe('Select', () => {
               >
                 <li
                   aria-selected="true"
-                  class="c14 c15 is-focused"
+                  class="c16 c17 is-focused"
                   data-strapi-value="pizza"
                   id="option-select1-pizza"
                   role="option"
                 >
                   <div
-                    class="c7"
+                    class="c6"
                   >
                     <span
-                      class="c16"
+                      class="c18"
                     >
                       Pizza
                     </span>
@@ -533,16 +565,16 @@ describe('Select', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c14 c15"
+                  class="c16 c17"
                   data-strapi-value="hamburger"
                   id="option-select1-hamburger"
                   role="option"
                 >
                   <div
-                    class="c7"
+                    class="c6"
                   >
                     <span
-                      class="c6"
+                      class="c9"
                     >
                       Hamburger
                     </span>
@@ -550,16 +582,16 @@ describe('Select', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c14 c15"
+                  class="c16 c17"
                   data-strapi-value="bagel"
                   id="option-select1-bagel"
                   role="option"
                 >
                   <div
-                    class="c7"
+                    class="c6"
                   >
                     <span
-                      class="c6"
+                      class="c9"
                     >
                       Bagel
                     </span>
@@ -601,20 +633,18 @@ describe('Select', () => {
 
     expect(container).toMatchInlineSnapshot(`
       <body>
-        .c4 {
-        font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans', 'Helvetica Neue',sans-serif;
-        text-align: left;
-        border: none;
-        padding-left: 16px;
-        padding-right: 16px;
-        padding-top: 12px;
-        padding-bottom: 12px;
-        display: block;
+        .c3 {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        top: 0;
         width: 100%;
         background: transparent;
+        border: none;
       }
 
-      .c4:focus {
+      .c3:focus {
         outline: none;
       }
 
@@ -625,21 +655,21 @@ describe('Select', () => {
         color: #32324d;
       }
 
-      .c5 {
+      .c8 {
         font-weight: 400;
         font-size: 0.875rem;
         line-height: 1.43;
         color: #32324d;
       }
 
-      .c11 {
+      .c13 {
         font-weight: 400;
         font-size: 0.75rem;
         line-height: 1.33;
         color: #666687;
       }
 
-      .c3 {
+      .c4 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -657,7 +687,7 @@ describe('Select', () => {
         align-items: center;
       }
 
-      .c7 {
+      .c6 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -671,7 +701,12 @@ describe('Select', () => {
         align-items: center;
       }
 
-      .c8 {
+      .c7 {
+        padding-right: 16px;
+        padding-left: 16px;
+      }
+
+      .c10 {
         padding-left: 12px;
       }
 
@@ -685,6 +720,7 @@ describe('Select', () => {
       }
 
       .c2 {
+        position: relative;
         border: 1px solid #dcdce4;
         padding-right: 12px;
         border-radius: 4px;
@@ -696,21 +732,23 @@ describe('Select', () => {
         border: 1px solid #4945ff;
       }
 
-      .c9 {
+      .c11 {
         background: transparent;
         border: none;
+        position: relative;
+        z-index: 1;
       }
 
-      .c9 svg {
+      .c11 svg {
         height: 0.6875rem;
         width: 0.6875rem;
       }
 
-      .c9 svg path {
+      .c11 svg path {
         fill: #666687;
       }
 
-      .c10 {
+      .c12 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -719,11 +757,11 @@ describe('Select', () => {
         border: none;
       }
 
-      .c10 svg {
+      .c12 svg {
         width: 0.375rem;
       }
 
-      .c6 {
+      .c9 {
         border: 0;
         -webkit-clip: rect(0 0 0 0);
         clip: rect(0 0 0 0);
@@ -733,6 +771,10 @@ describe('Select', () => {
         padding: 0;
         position: absolute;
         width: 1px;
+      }
+
+      .c5 {
+        min-height: 2.5rem;
       }
 
       <div>
@@ -749,37 +791,43 @@ describe('Select', () => {
             <div
               class="c2"
             >
-              <span
+              <button
+                aria-describedby="field-hint-select1"
+                aria-disabled="false"
+                aria-expanded="true"
+                aria-haspopup="listbox"
+                aria-labelledby="label-select1 content-select1"
                 class="c3"
+                id="select1"
+              />
+              <div
+                class="c4 c5"
               >
-                <button
-                  aria-describedby="field-hint-select1"
-                  aria-disabled="false"
-                  aria-expanded="true"
-                  aria-haspopup="listbox"
-                  aria-labelledby="label-select1 content-select1"
-                  class="c4"
-                  id="select1"
-                >
-                  <span
-                    aria-hidden="true"
-                    class="c5"
-                    id="content-select1"
-                  >
-                    Hamburger
-                    <span
-                      class="c6"
-                    >
-                      pizza, hamburger
-                    </span>
-                  </span>
-                </button>
                 <div
-                  class="c7"
+                  class="c6"
+                >
+                  <div
+                    class="c7"
+                  >
+                    <span
+                      class="c8"
+                      id="content-select1"
+                    >
+                      Hamburger
+                      <span
+                        class="c9"
+                      >
+                        pizza, hamburger
+                      </span>
+                    </span>
+                  </div>
+                </div>
+                <div
+                  class="c6"
                 >
                   <button
                     aria-hidden="true"
-                    class="c8 c9 c10"
+                    class="c10 c11 c12"
                     tabindex="-1"
                   >
                     <svg
@@ -798,10 +846,10 @@ describe('Select', () => {
                     </svg>
                   </button>
                 </div>
-              </span>
+              </div>
             </div>
             <p
-              class="c11"
+              class="c13"
               id="field-hint-select1"
             >
               Description line
@@ -1039,5 +1087,42 @@ describe('Select', () => {
         </div>
       </body>
     `);
+  });
+
+  describe('with tags', () => {
+    let rawError;
+
+    beforeEach(() => {
+      rawError = console.error;
+      console.error = () => undefined;
+    });
+
+    afterEach(() => {
+      console.error = rawError;
+    });
+
+    it('throws an error when passing the withTags prop without the multi one', () => {
+      expect(() =>
+        render(
+          <ThemeProvider theme={lightTheme}>
+            <Select
+              id="select1"
+              label="Choose your meal"
+              placeholder="Your example"
+              hint="Description line"
+              clearLabel="Clear the meal"
+              value={['pizza', 'hamburger']}
+              onChange={() => {}}
+              disabled={false}
+              withTags
+            >
+              <Option value={'pizza'}>Pizza</Option>
+              <Option value={'hamburger'}>Hamburger</Option>
+              <Option value={'bagel'}>Bagel</Option>
+            </Select>
+          </ThemeProvider>,
+        ),
+      ).toThrow(new Error('The "withTags" props can only be used when the "multi" prop is present'));
+    });
   });
 });

--- a/packages/strapi-design-system/src/Select/components.js
+++ b/packages/strapi-design-system/src/Select/components.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { Box } from '../Box';
 
 export const SelectButtonWrapper = styled.div`
+  position: relative;
   border: 1px solid ${({ theme, hasError }) => (hasError ? theme.colors.danger600 : theme.colors.neutral200)};
   padding-right: ${({ theme }) => theme.spaces[3]};
   border-radius: ${({ theme }) => theme.borderRadius};
@@ -24,6 +25,8 @@ export const SelectButtonWrapper = styled.div`
 export const IconBox = styled(Box)`
   background: transparent;
   border: none;
+  position: relative;
+  z-index: 1;
 
   svg {
     height: ${11 / 16}rem;

--- a/packages/strapi-design-system/src/Select/hooks/useListRef.js
+++ b/packages/strapi-design-system/src/Select/hooks/useListRef.js
@@ -25,7 +25,9 @@ export const useListRef = (expanded, onSelectItem, multi) => {
     }
 
     if (nextOption) {
-      changeDescendant(listRef.current, nextOption);
+      if (expanded === UpState.Keyboard || expanded === DownState.Keyboard) {
+        changeDescendant(listRef.current, nextOption);
+      }
 
       if (!multi) {
         onSelectItem(nextOption.getAttribute('data-strapi-value'));

--- a/packages/strapi-design-system/src/Tag/Tag.js
+++ b/packages/strapi-design-system/src/Tag/Tag.js
@@ -6,9 +6,16 @@ import { Box } from '../Box';
 import { Row } from '../Row';
 
 const TagWrapper = styled(Box)`
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans',
+    'Helvetica Neue', sans-serif;
   border: 1px solid ${({ theme }) => theme.colors.primary200};
   border-radius: ${({ theme }) => theme.borderRadius};
   height: ${32 / 16}rem;
+
+  svg {
+    height: ${8 / 16}rem;
+    width: ${8 / 16}rem;
+  }
 
   svg path {
     fill: ${({ theme }) => theme.colors.primary600};

--- a/packages/strapi-design-system/src/Tag/Tag.js
+++ b/packages/strapi-design-system/src/Tag/Tag.js
@@ -8,6 +8,7 @@ import { Row } from '../Row';
 const TagWrapper = styled(Box)`
   border: 1px solid ${({ theme }) => theme.colors.primary200};
   border-radius: ${({ theme }) => theme.borderRadius};
+  height: ${32 / 16}rem;
 
   svg path {
     fill: ${({ theme }) => theme.colors.primary600};
@@ -20,16 +21,7 @@ const TagText = styled(Text)`
 `;
 
 export const Tag = ({ children, icon, ...props }) => (
-  <TagWrapper
-    as="button"
-    background="primary100"
-    color="primary600"
-    paddingBottom={2}
-    paddingTop={2}
-    paddingLeft={3}
-    paddingRight={3}
-    {...props}
-  >
+  <TagWrapper as="button" background="primary100" color="primary600" paddingLeft={3} paddingRight={3} {...props}>
     <Row>
       <TagText small={true} highlighted={true} as="span">
         {children}

--- a/packages/strapi-design-system/src/Tag/__tests__/Tag.spec.js
+++ b/packages/strapi-design-system/src/Tag/__tests__/Tag.spec.js
@@ -47,9 +47,15 @@ describe('Tag', () => {
       }
 
       .c1 {
+        font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans', 'Helvetica Neue',sans-serif;
         border: 1px solid #d9d8ff;
         border-radius: 4px;
         height: 2rem;
+      }
+
+      .c1 svg {
+        height: 0.5rem;
+        width: 0.5rem;
       }
 
       .c1 svg path {

--- a/packages/strapi-design-system/src/Tag/__tests__/Tag.spec.js
+++ b/packages/strapi-design-system/src/Tag/__tests__/Tag.spec.js
@@ -24,9 +24,7 @@ describe('Tag', () => {
       .c0 {
         background: #f0f0ff;
         color: #4945ff;
-        padding-top: 8px;
         padding-right: 12px;
-        padding-bottom: 8px;
         padding-left: 12px;
       }
 
@@ -51,6 +49,7 @@ describe('Tag', () => {
       .c1 {
         border: 1px solid #d9d8ff;
         border-radius: 4px;
+        height: 2rem;
       }
 
       .c1 svg path {

--- a/packages/strapi-design-system/src/TimePicker/__tests__/TimePicker.spec.js
+++ b/packages/strapi-design-system/src/TimePicker/__tests__/TimePicker.spec.js
@@ -23,25 +23,23 @@ describe('TimePicker', () => {
       { container: document.body },
     );
 
-    fireEvent.mouseDown(screen.getByText('11:00'));
+    fireEvent.mouseDown(container.querySelector('#tp-1'));
 
     await waitFor(() => screen.getByText('00:00'));
 
     expect(container).toMatchInlineSnapshot(`
-      .c6 {
-        font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans', 'Helvetica Neue',sans-serif;
-        text-align: left;
-        border: none;
-        padding-left: 16px;
-        padding-right: 16px;
-        padding-top: 12px;
-        padding-bottom: 12px;
-        display: block;
+      .c3 {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        top: 0;
         width: 100%;
         background: transparent;
+        border: none;
       }
 
-      .c6:focus {
+      .c3:focus {
         outline: none;
       }
 
@@ -52,28 +50,28 @@ describe('TimePicker', () => {
         color: #32324d;
       }
 
-      .c7 {
+      .c10 {
         font-weight: 400;
         font-size: 0.875rem;
         line-height: 1.43;
         color: #32324d;
       }
 
-      .c11 {
+      .c13 {
         font-weight: 400;
         font-size: 0.75rem;
         line-height: 1.33;
         color: #666687;
       }
 
-      .c17 {
+      .c19 {
         font-weight: 500;
         font-size: 0.875rem;
         line-height: 1.43;
         color: #4945ff;
       }
 
-      .c3 {
+      .c4 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -91,7 +89,7 @@ describe('TimePicker', () => {
         align-items: center;
       }
 
-      .c8 {
+      .c6 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -105,17 +103,22 @@ describe('TimePicker', () => {
         align-items: center;
       }
 
-      .c4 {
+      .c7 {
         padding-left: 12px;
       }
 
-      .c12 {
+      .c9 {
+        padding-right: 16px;
+        padding-left: 16px;
+      }
+
+      .c14 {
         background: #ffffff;
         padding: 4px;
         border-radius: 4px;
       }
 
-      .c15 {
+      .c17 {
         background: #ffffff;
         padding-top: 8px;
         padding-right: 16px;
@@ -124,7 +127,7 @@ describe('TimePicker', () => {
         border-radius: 4px;
       }
 
-      .c13 {
+      .c15 {
         box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
         position: absolute;
         border: 1px solid #eaeaef;
@@ -132,16 +135,16 @@ describe('TimePicker', () => {
         margin-top: 4px;
       }
 
-      .c14 {
+      .c16 {
         max-height: 15rem;
         overflow-y: scroll;
       }
 
-      .c14::-webkit-scrollbar-track {
+      .c16::-webkit-scrollbar-track {
         background: #ffffff;
       }
 
-      .c14::-webkit-scrollbar-thumb {
+      .c16::-webkit-scrollbar-thumb {
         background: #eaeaef;
         border-radius: 4px;
         margin-right: 10px;
@@ -157,6 +160,7 @@ describe('TimePicker', () => {
       }
 
       .c2 {
+        position: relative;
         border: 1px solid #dcdce4;
         padding-right: 12px;
         border-radius: 4px;
@@ -168,21 +172,23 @@ describe('TimePicker', () => {
         border: 1px solid #4945ff;
       }
 
-      .c9 {
+      .c11 {
         background: transparent;
         border: none;
+        position: relative;
+        z-index: 1;
       }
 
-      .c9 svg {
+      .c11 svg {
         height: 0.6875rem;
         width: 0.6875rem;
       }
 
-      .c9 svg path {
+      .c11 svg path {
         fill: #666687;
       }
 
-      .c10 {
+      .c12 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -191,26 +197,30 @@ describe('TimePicker', () => {
         border: none;
       }
 
-      .c10 svg {
+      .c12 svg {
         width: 0.375rem;
       }
 
-      .c16 {
+      .c5 {
+        min-height: 2.5rem;
+      }
+
+      .c18 {
         width: 100%;
         border: none;
         text-align: left;
         outline-offset: -3px;
       }
 
-      .c16.is-focused {
+      .c18.is-focused {
         background: #f0f0ff;
       }
 
-      .c16:hover {
+      .c18:hover {
         background: #f0f0ff;
       }
 
-      .c5 {
+      .c8 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -221,12 +231,12 @@ describe('TimePicker', () => {
         align-items: center;
       }
 
-      .c5 svg {
+      .c8 svg {
         height: 1rem;
         width: 1rem;
       }
 
-      .c5 svg path {
+      .c8 svg path {
         fill: #8e8ea9;
       }
 
@@ -245,56 +255,62 @@ describe('TimePicker', () => {
             <div
               class="c2"
             >
-              <span
+              <button
+                aria-describedby="field-hint-tp-1"
+                aria-disabled="false"
+                aria-expanded="true"
+                aria-haspopup="listbox"
+                aria-labelledby="label-tp-1 content-tp-1"
                 class="c3"
+                id="tp-1"
+              />
+              <div
+                class="c4 c5"
               >
                 <div
-                  aria-hidden="true"
-                  class="c4"
+                  class="c6"
                 >
                   <div
-                    class="c5"
-                  >
-                    <svg
-                      fill="none"
-                      height="1em"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clip-rule="evenodd"
-                        d="M0 12C0 5.37 5.364 0 11.994 0S24 5.37 24 12s-5.376 12-12.006 12S0 18.63 0 12zm2.4 0c0 5.304 4.296 9.6 9.6 9.6 5.304 0 9.6-4.296 9.6-9.6 0-5.304-4.296-9.6-9.6-9.6A9.597 9.597 0 002.4 12zm8.4-6h1.8v6.3l5.4 3.204-.906 1.476L10.8 13.2V6z"
-                        fill="#212134"
-                        fill-rule="evenodd"
-                      />
-                    </svg>
-                  </div>
-                </div>
-                <button
-                  aria-describedby="field-hint-tp-1"
-                  aria-disabled="false"
-                  aria-expanded="true"
-                  aria-haspopup="listbox"
-                  aria-labelledby="label-tp-1 content-tp-1"
-                  class="c6"
-                  id="tp-1"
-                >
-                  <span
                     aria-hidden="true"
                     class="c7"
-                    id="content-tp-1"
                   >
-                    11:00
-                  </span>
-                </button>
+                    <div
+                      class="c8"
+                    >
+                      <svg
+                        fill="none"
+                        height="1em"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M0 12C0 5.37 5.364 0 11.994 0S24 5.37 24 12s-5.376 12-12.006 12S0 18.63 0 12zm2.4 0c0 5.304 4.296 9.6 9.6 9.6 5.304 0 9.6-4.296 9.6-9.6 0-5.304-4.296-9.6-9.6-9.6A9.597 9.597 0 002.4 12zm8.4-6h1.8v6.3l5.4 3.204-.906 1.476L10.8 13.2V6z"
+                          fill="#212134"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    class="c9"
+                  >
+                    <span
+                      class="c10"
+                      id="content-tp-1"
+                    >
+                      11:00
+                    </span>
+                  </div>
+                </div>
                 <div
-                  class="c8"
+                  class="c6"
                 >
                   <button
                     aria-disabled="false"
                     aria-label="Clear the selected time picker value"
-                    class="c9"
+                    class="c11"
                   >
                     <svg
                       fill="none"
@@ -311,7 +327,7 @@ describe('TimePicker', () => {
                   </button>
                   <button
                     aria-hidden="true"
-                    class="c4 c9 c10"
+                    class="c7 c11 c12"
                     tabindex="-1"
                   >
                     <svg
@@ -330,10 +346,10 @@ describe('TimePicker', () => {
                     </svg>
                   </button>
                 </div>
-              </span>
+              </div>
             </div>
             <p
-              class="c11"
+              class="c13"
               id="field-hint-tp-1"
             >
               Description line
@@ -344,11 +360,11 @@ describe('TimePicker', () => {
           data-react-portal="true"
         >
           <div
-            class="c12 c13"
+            class="c14 c15"
             style="left: 0px; top: 0px;"
           >
             <div
-              class="c14"
+              class="c16"
             >
               <ul
                 aria-activedescendant="option-tp-1-11-00"
@@ -360,16 +376,16 @@ describe('TimePicker', () => {
               >
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="00:00"
                   id="option-tp-1-00-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       00:00
                     </span>
@@ -377,16 +393,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="00:15"
                   id="option-tp-1-00-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       00:15
                     </span>
@@ -394,16 +410,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="00:30"
                   id="option-tp-1-00-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       00:30
                     </span>
@@ -411,16 +427,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="00:45"
                   id="option-tp-1-00-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       00:45
                     </span>
@@ -428,16 +444,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="01:00"
                   id="option-tp-1-01-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       01:00
                     </span>
@@ -445,16 +461,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="01:15"
                   id="option-tp-1-01-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       01:15
                     </span>
@@ -462,16 +478,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="01:30"
                   id="option-tp-1-01-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       01:30
                     </span>
@@ -479,16 +495,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="01:45"
                   id="option-tp-1-01-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       01:45
                     </span>
@@ -496,16 +512,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="02:00"
                   id="option-tp-1-02-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       02:00
                     </span>
@@ -513,16 +529,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="02:15"
                   id="option-tp-1-02-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       02:15
                     </span>
@@ -530,16 +546,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="02:30"
                   id="option-tp-1-02-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       02:30
                     </span>
@@ -547,16 +563,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="02:45"
                   id="option-tp-1-02-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       02:45
                     </span>
@@ -564,16 +580,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="03:00"
                   id="option-tp-1-03-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       03:00
                     </span>
@@ -581,16 +597,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="03:15"
                   id="option-tp-1-03-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       03:15
                     </span>
@@ -598,16 +614,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="03:30"
                   id="option-tp-1-03-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       03:30
                     </span>
@@ -615,16 +631,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="03:45"
                   id="option-tp-1-03-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       03:45
                     </span>
@@ -632,16 +648,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="04:00"
                   id="option-tp-1-04-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       04:00
                     </span>
@@ -649,16 +665,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="04:15"
                   id="option-tp-1-04-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       04:15
                     </span>
@@ -666,16 +682,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="04:30"
                   id="option-tp-1-04-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       04:30
                     </span>
@@ -683,16 +699,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="04:45"
                   id="option-tp-1-04-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       04:45
                     </span>
@@ -700,16 +716,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="05:00"
                   id="option-tp-1-05-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       05:00
                     </span>
@@ -717,16 +733,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="05:15"
                   id="option-tp-1-05-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       05:15
                     </span>
@@ -734,16 +750,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="05:30"
                   id="option-tp-1-05-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       05:30
                     </span>
@@ -751,16 +767,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="05:45"
                   id="option-tp-1-05-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       05:45
                     </span>
@@ -768,16 +784,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="06:00"
                   id="option-tp-1-06-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       06:00
                     </span>
@@ -785,16 +801,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="06:15"
                   id="option-tp-1-06-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       06:15
                     </span>
@@ -802,16 +818,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="06:30"
                   id="option-tp-1-06-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       06:30
                     </span>
@@ -819,16 +835,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="06:45"
                   id="option-tp-1-06-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       06:45
                     </span>
@@ -836,16 +852,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="07:00"
                   id="option-tp-1-07-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       07:00
                     </span>
@@ -853,16 +869,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="07:15"
                   id="option-tp-1-07-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       07:15
                     </span>
@@ -870,16 +886,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="07:30"
                   id="option-tp-1-07-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       07:30
                     </span>
@@ -887,16 +903,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="07:45"
                   id="option-tp-1-07-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       07:45
                     </span>
@@ -904,16 +920,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="08:00"
                   id="option-tp-1-08-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       08:00
                     </span>
@@ -921,16 +937,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="08:15"
                   id="option-tp-1-08-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       08:15
                     </span>
@@ -938,16 +954,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="08:30"
                   id="option-tp-1-08-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       08:30
                     </span>
@@ -955,16 +971,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="08:45"
                   id="option-tp-1-08-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       08:45
                     </span>
@@ -972,16 +988,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="09:00"
                   id="option-tp-1-09-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       09:00
                     </span>
@@ -989,16 +1005,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="09:15"
                   id="option-tp-1-09-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       09:15
                     </span>
@@ -1006,16 +1022,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="09:30"
                   id="option-tp-1-09-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       09:30
                     </span>
@@ -1023,16 +1039,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="09:45"
                   id="option-tp-1-09-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       09:45
                     </span>
@@ -1040,16 +1056,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="10:00"
                   id="option-tp-1-10-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       10:00
                     </span>
@@ -1057,16 +1073,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="10:15"
                   id="option-tp-1-10-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       10:15
                     </span>
@@ -1074,16 +1090,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="10:30"
                   id="option-tp-1-10-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       10:30
                     </span>
@@ -1091,16 +1107,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="10:45"
                   id="option-tp-1-10-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       10:45
                     </span>
@@ -1108,16 +1124,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="true"
-                  class="c15 c16 is-focused"
+                  class="c17 c18 is-focused"
                   data-strapi-value="11:00"
                   id="option-tp-1-11-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c17"
+                      class="c19"
                     >
                       11:00
                     </span>
@@ -1125,16 +1141,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="11:15"
                   id="option-tp-1-11-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       11:15
                     </span>
@@ -1142,16 +1158,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="11:30"
                   id="option-tp-1-11-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       11:30
                     </span>
@@ -1159,16 +1175,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="11:45"
                   id="option-tp-1-11-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       11:45
                     </span>
@@ -1176,16 +1192,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="12:00"
                   id="option-tp-1-12-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       12:00
                     </span>
@@ -1193,16 +1209,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="12:15"
                   id="option-tp-1-12-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       12:15
                     </span>
@@ -1210,16 +1226,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="12:30"
                   id="option-tp-1-12-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       12:30
                     </span>
@@ -1227,16 +1243,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="12:45"
                   id="option-tp-1-12-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       12:45
                     </span>
@@ -1244,16 +1260,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="13:00"
                   id="option-tp-1-13-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       13:00
                     </span>
@@ -1261,16 +1277,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="13:15"
                   id="option-tp-1-13-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       13:15
                     </span>
@@ -1278,16 +1294,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="13:30"
                   id="option-tp-1-13-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       13:30
                     </span>
@@ -1295,16 +1311,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="13:45"
                   id="option-tp-1-13-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       13:45
                     </span>
@@ -1312,16 +1328,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="14:00"
                   id="option-tp-1-14-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       14:00
                     </span>
@@ -1329,16 +1345,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="14:15"
                   id="option-tp-1-14-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       14:15
                     </span>
@@ -1346,16 +1362,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="14:30"
                   id="option-tp-1-14-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       14:30
                     </span>
@@ -1363,16 +1379,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="14:45"
                   id="option-tp-1-14-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       14:45
                     </span>
@@ -1380,16 +1396,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="15:00"
                   id="option-tp-1-15-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       15:00
                     </span>
@@ -1397,16 +1413,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="15:15"
                   id="option-tp-1-15-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       15:15
                     </span>
@@ -1414,16 +1430,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="15:30"
                   id="option-tp-1-15-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       15:30
                     </span>
@@ -1431,16 +1447,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="15:45"
                   id="option-tp-1-15-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       15:45
                     </span>
@@ -1448,16 +1464,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="16:00"
                   id="option-tp-1-16-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       16:00
                     </span>
@@ -1465,16 +1481,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="16:15"
                   id="option-tp-1-16-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       16:15
                     </span>
@@ -1482,16 +1498,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="16:30"
                   id="option-tp-1-16-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       16:30
                     </span>
@@ -1499,16 +1515,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="16:45"
                   id="option-tp-1-16-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       16:45
                     </span>
@@ -1516,16 +1532,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="17:00"
                   id="option-tp-1-17-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       17:00
                     </span>
@@ -1533,16 +1549,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="17:15"
                   id="option-tp-1-17-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       17:15
                     </span>
@@ -1550,16 +1566,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="17:30"
                   id="option-tp-1-17-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       17:30
                     </span>
@@ -1567,16 +1583,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="17:45"
                   id="option-tp-1-17-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       17:45
                     </span>
@@ -1584,16 +1600,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="18:00"
                   id="option-tp-1-18-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       18:00
                     </span>
@@ -1601,16 +1617,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="18:15"
                   id="option-tp-1-18-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       18:15
                     </span>
@@ -1618,16 +1634,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="18:30"
                   id="option-tp-1-18-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       18:30
                     </span>
@@ -1635,16 +1651,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="18:45"
                   id="option-tp-1-18-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       18:45
                     </span>
@@ -1652,16 +1668,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="19:00"
                   id="option-tp-1-19-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       19:00
                     </span>
@@ -1669,16 +1685,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="19:15"
                   id="option-tp-1-19-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       19:15
                     </span>
@@ -1686,16 +1702,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="19:30"
                   id="option-tp-1-19-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       19:30
                     </span>
@@ -1703,16 +1719,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="19:45"
                   id="option-tp-1-19-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       19:45
                     </span>
@@ -1720,16 +1736,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="20:00"
                   id="option-tp-1-20-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       20:00
                     </span>
@@ -1737,16 +1753,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="20:15"
                   id="option-tp-1-20-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       20:15
                     </span>
@@ -1754,16 +1770,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="20:30"
                   id="option-tp-1-20-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       20:30
                     </span>
@@ -1771,16 +1787,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="20:45"
                   id="option-tp-1-20-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       20:45
                     </span>
@@ -1788,16 +1804,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="21:00"
                   id="option-tp-1-21-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       21:00
                     </span>
@@ -1805,16 +1821,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="21:15"
                   id="option-tp-1-21-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       21:15
                     </span>
@@ -1822,16 +1838,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="21:30"
                   id="option-tp-1-21-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       21:30
                     </span>
@@ -1839,16 +1855,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="21:45"
                   id="option-tp-1-21-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       21:45
                     </span>
@@ -1856,16 +1872,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="22:00"
                   id="option-tp-1-22-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       22:00
                     </span>
@@ -1873,16 +1889,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="22:15"
                   id="option-tp-1-22-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       22:15
                     </span>
@@ -1890,16 +1906,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="22:30"
                   id="option-tp-1-22-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       22:30
                     </span>
@@ -1907,16 +1923,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="22:45"
                   id="option-tp-1-22-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       22:45
                     </span>
@@ -1924,16 +1940,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="23:00"
                   id="option-tp-1-23-00"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       23:00
                     </span>
@@ -1941,16 +1957,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="23:15"
                   id="option-tp-1-23-15"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       23:15
                     </span>
@@ -1958,16 +1974,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="23:30"
                   id="option-tp-1-23-30"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       23:30
                     </span>
@@ -1975,16 +1991,16 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="false"
-                  class="c15 c16"
+                  class="c17 c18"
                   data-strapi-value="23:45"
                   id="option-tp-1-23-45"
                   role="option"
                 >
                   <div
-                    class="c8"
+                    class="c6"
                   >
                     <span
-                      class="c7"
+                      class="c10"
                     >
                       23:45
                     </span>

--- a/packages/strapi-design-system/src/TimePicker/__tests__/TimePicker.spec.js
+++ b/packages/strapi-design-system/src/TimePicker/__tests__/TimePicker.spec.js
@@ -140,6 +140,11 @@ describe('TimePicker', () => {
         overflow-y: scroll;
       }
 
+      .c16::-webkit-scrollbar {
+        -webkit-appearance: none;
+        width: 4px;
+      }
+
       .c16::-webkit-scrollbar-track {
         background: #ffffff;
       }
@@ -367,7 +372,6 @@ describe('TimePicker', () => {
               class="c16"
             >
               <ul
-                aria-activedescendant="option-tp-1-11-00"
                 aria-labelledby="label-tp-1"
                 aria-multiselectable="false"
                 class="c0"
@@ -1124,7 +1128,7 @@ describe('TimePicker', () => {
                 </li>
                 <li
                   aria-selected="true"
-                  class="c17 c18 is-focused"
+                  class="c17 c18"
                   data-strapi-value="11:00"
                   id="option-tp-1-11-00"
                   role="option"


### PR DESCRIPTION
# Select multi tags

## Description

Add a `withTags` props to the component

## Demo

Example on : https://design-system-git-select-multi-tags-strapijs.vercel.app/?path=/story/design-system-atoms-select--multi-with-tags

## API

```diff
<Select
    id="select1"
    label="Choose your meal"
    placeholder="Your example"
    onClear={() => setValues([])}
    hint="Description line"
    clearLabel="Clear the meal"
    error={error}
    value={values}
    onChange={onValueChange}
    disabled={disabled}
    customizeContent={(values) => `${values.length} currently selected`}
    multi
+  withTags
  >
    <Option value={'pizza'}>Pizza</Option>
    <Option value={'hamburger'}>Hamburger</Option>
    <Option value={'bagel'}>Bagel</Option>
</Select>
```

## Voiceover

![Selecting pizza and hamburger in in listbox](https://user-images.githubusercontent.com/3874873/123390673-7553b780-d59b-11eb-8085-723123040d23.gif)
