### PR TITLE
Homogeneize height of inputs

### DIFF
--- a/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
+++ b/example/src/shared/GenericInput/__tests__/GenericInput.spec.js
@@ -69,7 +69,7 @@ describe("GenericInput", () => {
               >
                 <input
                   aria-invalid="false"
-                  class="sc-bkbkJK blykGF"
+                  class="sc-bkbkJK kiUQEJ"
                   id="field-some-id"
                   name="some text"
                   type="text"

--- a/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.spec.js
+++ b/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.spec.js
@@ -80,13 +80,12 @@ describe('DatePicker', () => {
         border: none;
         padding-left: 0;
         padding-right: 16px;
-        padding-top: 12px;
-        padding-bottom: 12px;
         color: #32324d;
         font-weight: 400;
         font-size: 0.875rem;
         display: block;
         width: 100%;
+        height: 2.5rem;
       }
 
       .c8::-webkit-input-placeholder {

--- a/packages/strapi-design-system/src/Field/FieldAction.js
+++ b/packages/strapi-design-system/src/Field/FieldAction.js
@@ -15,7 +15,7 @@ const FieldActionWrapper = styled.button`
 
 export const FieldAction = ({ label, children, ...props }) => (
   <FieldActionWrapper aria-label={label} {...props}>
-    <span aria-hidden={true}>{children}</span>
+    {children}
   </FieldActionWrapper>
 );
 

--- a/packages/strapi-design-system/src/Field/FieldInput.js
+++ b/packages/strapi-design-system/src/Field/FieldInput.js
@@ -9,8 +9,6 @@ const Input = styled.input`
   border: none;
   padding-left: ${({ theme, hasLeftAction }) => (hasLeftAction ? 0 : theme.spaces[4])};
   padding-right: ${({ theme, hasRightAction }) => (hasRightAction ? 0 : theme.spaces[4])};
-  padding-top: ${({ theme }) => `${theme.spaces[3]}`};
-  padding-bottom: ${({ theme }) => `${theme.spaces[3]}`};
 
   color: ${({ theme }) => theme.colors.neutral800};
   font-weight: 400;
@@ -18,6 +16,7 @@ const Input = styled.input`
   font-size: ${14 / 16}rem;
   display: block;
   width: 100%;
+  height: ${40 / 16}rem;
 
   ::placeholder {
     color: ${({ theme }) => theme.colors.neutral500};

--- a/packages/strapi-design-system/src/Field/__tests__/Field.spec.js
+++ b/packages/strapi-design-system/src/Field/__tests__/Field.spec.js
@@ -54,13 +54,12 @@ describe('Field', () => {
         border: none;
         padding-left: 16px;
         padding-right: 16px;
-        padding-top: 12px;
-        padding-bottom: 12px;
         color: #32324d;
         font-weight: 400;
         font-size: 0.875rem;
         display: block;
         width: 100%;
+        height: 2.5rem;
       }
 
       .c3::-webkit-input-placeholder {
@@ -175,13 +174,12 @@ describe('Field', () => {
         border: none;
         padding-left: 16px;
         padding-right: 16px;
-        padding-top: 12px;
-        padding-bottom: 12px;
         color: #32324d;
         font-weight: 400;
         font-size: 0.875rem;
         display: block;
         width: 100%;
+        height: 2.5rem;
       }
 
       .c3::-webkit-input-placeholder {
@@ -304,13 +302,12 @@ describe('Field', () => {
         border: none;
         padding-left: 16px;
         padding-right: 16px;
-        padding-top: 12px;
-        padding-bottom: 12px;
         color: #32324d;
         font-weight: 400;
         font-size: 0.875rem;
         display: block;
         width: 100%;
+        height: 2.5rem;
       }
 
       .c3::-webkit-input-placeholder {
@@ -439,13 +436,12 @@ describe('Field', () => {
         border: none;
         padding-left: 16px;
         padding-right: 16px;
-        padding-top: 12px;
-        padding-bottom: 12px;
         color: #32324d;
         font-weight: 400;
         font-size: 0.875rem;
         display: block;
         width: 100%;
+        height: 2.5rem;
       }
 
       .c3::-webkit-input-placeholder {
@@ -590,13 +586,12 @@ describe('Field', () => {
         border: none;
         padding-left: 0;
         padding-right: 0;
-        padding-top: 12px;
-        padding-bottom: 12px;
         color: #32324d;
         font-weight: 400;
         font-size: 0.875rem;
         display: block;
         width: 100%;
+        height: 2.5rem;
       }
 
       .c5::-webkit-input-placeholder {
@@ -675,11 +670,7 @@ describe('Field', () => {
               aria-label="Show password"
               class="c4"
             >
-              <span
-                aria-hidden="true"
-              >
-                Show
-              </span>
+              Show
             </button>
           </div>
           <input
@@ -700,11 +691,7 @@ describe('Field', () => {
               aria-label="Show password"
               class="c4"
             >
-              <span
-                aria-hidden="true"
-              >
-                Hide
-              </span>
+              Hide
             </button>
           </div>
         </div>

--- a/packages/strapi-design-system/src/Searchbar/__tests__/Searchbar.spec.js
+++ b/packages/strapi-design-system/src/Searchbar/__tests__/Searchbar.spec.js
@@ -80,13 +80,12 @@ describe('Searchbar', () => {
         border: none;
         padding-left: 0;
         padding-right: 0;
-        padding-top: 12px;
-        padding-bottom: 12px;
         color: #32324d;
         font-weight: 400;
         font-size: 0.875rem;
         display: block;
         width: 100%;
+        height: 2.5rem;
       }
 
       .c10::-webkit-input-placeholder {
@@ -245,26 +244,22 @@ describe('Searchbar', () => {
                 aria-label="Clearing the plugin search"
                 class="c12"
               >
-                <span
-                  aria-hidden="true"
+                <div
+                  class="c8 c13"
                 >
-                  <div
-                    class="c8 c13"
+                  <svg
+                    fill="none"
+                    height="1em"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <svg
-                      fill="none"
-                      height="1em"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M24 2.417L21.583 0 12 9.583 2.417 0 0 2.417 9.583 12 0 21.583 2.417 24 12 14.417 21.583 24 24 21.583 14.417 12 24 2.417z"
-                        fill="#212134"
-                      />
-                    </svg>
-                  </div>
-                </span>
+                    <path
+                      d="M24 2.417L21.583 0 12 9.583 2.417 0 0 2.417 9.583 12 0 21.583 2.417 24 12 14.417 21.583 24 24 21.583 14.417 12 24 2.417z"
+                      fill="#212134"
+                    />
+                  </svg>
+                </div>
               </button>
             </div>
           </div>

--- a/packages/strapi-design-system/src/TextInput/__tests__/TextInput.spec.js
+++ b/packages/strapi-design-system/src/TextInput/__tests__/TextInput.spec.js
@@ -80,13 +80,12 @@ describe('TextInput', () => {
         border: none;
         padding-left: 16px;
         padding-right: 16px;
-        padding-top: 12px;
-        padding-bottom: 12px;
         color: #32324d;
         font-weight: 400;
         font-size: 0.875rem;
         display: block;
         width: 100%;
+        height: 2.5rem;
       }
 
       .c7::-webkit-input-placeholder {


### PR DESCRIPTION
This PR removes the padding top / bottom of the field input and make it be `40/16 rem` high. The aim is to make the alignment of the select component and field input possible.

Another iteration will come for the select component