### PR TITLE
ResizeObserver on Popover

### DIFF
--- a/packages/strapi-design-system/src/Popover/Popover.js
+++ b/packages/strapi-design-system/src/Popover/Popover.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Box } from '../Box';
@@ -49,7 +49,20 @@ const PopoverScrollable = styled(Box)`
 
 const PopoverContent = ({ source, children, spacingTop, fullWidth, onReachEnd, intersectionId, ...props }) => {
   const popoverRef = useRef(null);
-  const { left, top, width } = position(source.current, fullWidth);
+  const [{ left, top, width }, setPosition] = useState(position(source.current, fullWidth));
+
+  useEffect(() => {
+    const resizeHandler = () => {
+      setPosition(position(source.current, fullWidth));
+    };
+
+    const resizeObs = new ResizeObserver(resizeHandler);
+    resizeObs.observe(source.current);
+
+    return () => {
+      resizeObs.disconnect();
+    };
+  }, []);
 
   useIntersection(popoverRef, onReachEnd, {
     selectorToWatch: `#${intersectionId}`,

--- a/packages/strapi-design-system/src/Select/__tests__/Select.spec.js
+++ b/packages/strapi-design-system/src/Select/__tests__/Select.spec.js
@@ -6,13 +6,6 @@ import { ThemeProvider } from '../../ThemeProvider';
 import { lightTheme } from '../../themes';
 
 describe('Select', () => {
-  beforeEach(() => {
-    window.IntersectionObserver = () => ({
-      observe: () => {},
-      disconnect: () => {},
-    });
-  });
-
   it('snapshots the component', () => {
     const { container } = render(
       <ThemeProvider theme={lightTheme}>

--- a/packages/strapi-design-system/test-bundler.js
+++ b/packages/strapi-design-system/test-bundler.js
@@ -1,1 +1,11 @@
 import 'jest-styled-components';
+
+window.ResizeObserver = () => ({
+  observe: () => {},
+  disconnect: () => {},
+});
+
+window.IntersectionObserver = () => ({
+  observe: () => {},
+  disconnect: () => {},
+});


### PR DESCRIPTION
## Description

Adds a ResizeObserver on Popover so that it can repositioned itself when the source container grows such as the Input in the Select multi tags example

## Demo
Example on : https://design-system-git-resize-popover-strapijs.vercel.app/?path=/story/design-system-atoms-select--multi-with-tags

## In action

![Filling multiple value in the select component](https://user-images.githubusercontent.com/3874873/123594837-77628400-d7f0-11eb-8ba8-f3a2a18d3186.gif)
