### PR TITLE
Add stories for tokens and icons (and refacto grid)

### DIFF
--- a/packages/strapi-design-system/src/Grid/Grid.js
+++ b/packages/strapi-design-system/src/Grid/Grid.js
@@ -7,7 +7,6 @@ import { Box } from '../Box';
 const GridWrapper = styled(Box)`
   display: grid;
   gap: ${({ gap, theme }) => theme.spaces[gap]};
-
   grid-template-columns: repeat(${({ gridCols }) => gridCols}, 1fr);
 `;
 

--- a/packages/strapi-design-system/src/Grid/Grid.js
+++ b/packages/strapi-design-system/src/Grid/Grid.js
@@ -5,28 +5,16 @@ import { GridContext } from './GridContext';
 import { Box } from '../Box';
 
 const GridWrapper = styled(Box)`
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  gap: ${({ gap, theme }) => theme.spaces[gap]};
 
-  & > * {
-    margin-right: ${({ gap, theme }) => theme.spaces[gap]};
-    margin-top: ${({ gap, theme }) => theme.spaces[gap]};
-  }
-
-  margin-right: -${({ gap, theme }) => theme.spaces[gap]};
-  margin-top: -${({ gap, theme }) => theme.spaces[gap]};
-`;
-
-const GridContainer = styled.div`
-  overflow: hidden;
+  grid-template-columns: repeat(${({ gridCols }) => gridCols}, 1fr);
 `;
 
 export const Grid = ({ gap, gridCols, ...props }) => {
   return (
     <GridContext.Provider value={{ gap, gridCols }}>
-      <GridContainer>
-        <GridWrapper gap={gap} {...props} />
-      </GridContainer>
+      <GridWrapper gap={gap} gridCols={gridCols} {...props} />
     </GridContext.Provider>
   );
 };

--- a/packages/strapi-design-system/src/Grid/Grid.stories.mdx
+++ b/packages/strapi-design-system/src/Grid/Grid.stories.mdx
@@ -55,31 +55,31 @@ A more complex one
 <Canvas>
   <Story name="complex grid">
     <Grid gap={5} background={'primary200'}>
-      <GridItem background="neutral100" padding={5} col={6}>
+      <GridItem background="neutral100" padding={1} col={6}>
         Some box 1
       </GridItem>
-      <GridItem background="neutral100" padding={5} col={6}>
+      <GridItem background="neutral100" padding={1} col={6}>
         Some box 2
       </GridItem>
-      <GridItem background="neutral100" padding={5} col={3}>
+      <GridItem background="neutral100" padding={1} col={3}>
         Some box 3
       </GridItem>
-      <GridItem background="neutral100" padding={5} col={3}>
+      <GridItem background="neutral100" padding={1} col={3}>
         Some box 4
       </GridItem>
-      <GridItem background="neutral100" padding={5} col={3}>
+      <GridItem background="neutral100" padding={1} col={3}>
         Some box 5
       </GridItem>
-      <GridItem background="neutral100" padding={5} col={3}>
+      <GridItem background="neutral100" padding={1} col={3}>
         Some box 6
       </GridItem>
-      <GridItem background="neutral100" padding={5} col={9}>
+      <GridItem background="neutral100" padding={1} col={8}>
         Some box 7
       </GridItem>
-      <GridItem background="neutral100" padding={5} col={2}>
+      <GridItem background="neutral100" padding={1} col={2}>
         Some box 8
       </GridItem>
-      <GridItem background="neutral100" padding={5} col={1}>
+      <GridItem background="neutral100" padding={5} col={2}>
         Some box 9
       </GridItem>
     </Grid>

--- a/packages/strapi-design-system/src/Grid/GridItem.js
+++ b/packages/strapi-design-system/src/Grid/GridItem.js
@@ -1,16 +1,23 @@
 import React from 'react';
 import styled from 'styled-components';
+import PropTypes from 'prop-types';
 import { Box } from '../Box';
 import { useGrid } from './GridContext';
 
-const GridItemWrapper = styled(Box)`
-  flex: ${({ col }) => col};
-  flex-basis: ${({ col, theme, gap, gridCols }) =>
-    col ? `calc(${(col / gridCols) * 100}% - ${theme.spaces[gap]})` : undefined};
+const GridItemWrapper = styled.div`
+  grid-column: span ${({ col }) => col};
 `;
 
-export const GridItem = (props) => {
+export const GridItem = ({ col, ...props }) => {
   const { gap, gridCols } = useGrid();
 
-  return <GridItemWrapper gap={gap} gridCols={gridCols} {...props} />;
+  return (
+    <GridItemWrapper gap={gap} gridCols={gridCols} col={col}>
+      <Box {...props} />
+    </GridItemWrapper>
+  );
+};
+
+GridItem.propTypes = {
+  col: PropTypes.number.isRequired,
 };

--- a/packages/strapi-design-system/src/Grid/GridItem.js
+++ b/packages/strapi-design-system/src/Grid/GridItem.js
@@ -6,6 +6,7 @@ import { useGrid } from './GridContext';
 
 const GridItemWrapper = styled.div`
   grid-column: span ${({ col }) => col};
+  word-break: break-all;
 `;
 
 export const GridItem = ({ col, ...props }) => {

--- a/packages/strapi-design-system/src/Grid/__tests__/Grid.spec.js
+++ b/packages/strapi-design-system/src/Grid/__tests__/Grid.spec.js
@@ -43,14 +43,17 @@ describe('Grid', () => {
 
       .c2 {
         grid-column: span 6;
+        word-break: break-all;
       }
 
       .c4 {
         grid-column: span 9;
+        word-break: break-all;
       }
 
       .c5 {
         grid-column: span 3;
+        word-break: break-all;
       }
 
       <div

--- a/packages/strapi-design-system/src/Grid/__tests__/Grid.spec.js
+++ b/packages/strapi-design-system/src/Grid/__tests__/Grid.spec.js
@@ -23,7 +23,7 @@ describe('Grid', () => {
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
-      .c1 {
+      .c0 {
         padding: 16px;
       }
 
@@ -35,77 +35,59 @@ describe('Grid', () => {
         background: #66b7f1;
       }
 
+      .c1 {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(12,1fr);
+      }
+
       .c2 {
-        display: -webkit-box;
-        display: -webkit-flex;
-        display: -ms-flexbox;
-        display: flex;
-        -webkit-flex-wrap: wrap;
-        -ms-flex-wrap: wrap;
-        flex-wrap: wrap;
-        margin-right: -16px;
-        margin-top: -16px;
-      }
-
-      .c2 > * {
-        margin-right: 16px;
-        margin-top: 16px;
-      }
-
-      .c0 {
-        overflow: hidden;
+        grid-column: span 6;
       }
 
       .c4 {
-        -webkit-flex: 6;
-        -ms-flex: 6;
-        flex: 6;
-        -webkit-flex-basis: calc(50% - 16px);
-        -ms-flex-preferred-size: calc(50% - 16px);
-        flex-basis: calc(50% - 16px);
+        grid-column: span 9;
       }
 
       .c5 {
-        -webkit-flex: 9;
-        -ms-flex: 9;
-        flex: 9;
-        -webkit-flex-basis: calc(75% - 16px);
-        -ms-flex-preferred-size: calc(75% - 16px);
-        flex-basis: calc(75% - 16px);
-      }
-
-      .c7 {
-        -webkit-flex: 3;
-        -ms-flex: 3;
-        flex: 3;
-        -webkit-flex-basis: calc(25% - 16px);
-        -ms-flex-preferred-size: calc(25% - 16px);
-        flex-basis: calc(25% - 16px);
+        grid-column: span 3;
       }
 
       <div
-        class="c0"
+        class="c0 c1"
       >
         <div
-          class="c1 c2"
+          class="c2"
         >
           <div
-            class="c3 c4"
+            class="c3"
           >
             First
           </div>
+        </div>
+        <div
+          class="c2"
+        >
           <div
-            class="c4"
+            class=""
           >
             Second
           </div>
+        </div>
+        <div
+          class="c4"
+        >
           <div
-            class="c5"
+            class=""
           >
             Third
           </div>
+        </div>
+        <div
+          class="c5"
+        >
           <div
-            class="c6 c7"
+            class="c6"
           >
             Last
           </div>

--- a/packages/strapi-design-system/src/Tooltip/Tooltip.stories.mdx
+++ b/packages/strapi-design-system/src/Tooltip/Tooltip.stories.mdx
@@ -3,7 +3,7 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import { Tooltip } from './Tooltip';
 import { Box } from '../Box';
-import { Grid } from '../Grid';
+import { Grid, GridItem } from '../Grid';
 
 <Meta title="Design System/Molecules/Tooltip" component={Tooltip} />
 

--- a/packages/strapi-design-system/src/themes/Theme.stories.mdx
+++ b/packages/strapi-design-system/src/themes/Theme.stories.mdx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import { Box } from '../Box';
+import { Row } from '../Row';
+import { Text } from '../Text';
 import { Grid, GridItem } from '../Grid';
 import { useTheme } from '../ThemeProvider';
 import { Stack } from '../Stack';
@@ -13,7 +15,7 @@ import { Stack } from '../Stack';
 
 This is the doc of the `TimePicker` component
 
-## LightTheme
+## Colors
 
 Description...
 
@@ -53,6 +55,60 @@ Description...
               </GridItem>
             ))}
           </Grid>
+        </Box>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Shadows
+
+Description...
+
+<Canvas>
+  <Story name="shadows">
+    {() => {
+      const theme = useTheme();
+      const shadows = Object.keys(theme.shadows);
+      return (
+        <Box padding={8} background="neutral100">
+          <Grid gap={4}>
+            {shadows.map((shadow) => (
+              <GridItem padding={8} shadow={shadow} background="neutral0">
+                {shadow}
+              </GridItem>
+            ))}
+          </Grid>
+        </Box>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Spaces
+
+Description...
+
+<Canvas>
+  <Story name="spaces">
+    {() => {
+      const theme = useTheme();
+      const spaces = Object.keys(theme.spaces);
+      return (
+        <Box padding={8} background="neutral100">
+          <Stack>
+            {spaces.map((space) => (
+              <Row key={`space-${space}`}>
+                <Box background="primary500" hasRadius style={{ width: `${space * 4}px`, height: '4px' }} />
+                <Box paddingLeft={2}>
+                  <Text as="span">{space}</Text>{' '}
+                  <Text small as="span">
+                    ({space * 4}px)
+                  </Text>
+                </Box>
+              </Row>
+            ))}
+          </Stack>
         </Box>
       );
     }}

--- a/packages/strapi-design-system/src/themes/Theme.stories.mdx
+++ b/packages/strapi-design-system/src/themes/Theme.stories.mdx
@@ -1,6 +1,7 @@
 <!--- TimePicker.stories.mdx --->
 
 import { useState } from 'react';
+import * as Icons from '@strapi/icons';
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import { Box } from '../Box';
 import { Row } from '../Row';
@@ -109,6 +110,38 @@ Description...
               </Row>
             ))}
           </Stack>
+        </Box>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Icons
+
+Description...
+
+<Canvas>
+  <Story name="icons">
+    {() => {
+      console.log('wtf', Icons);
+      const iconsArray = Object.keys(Icons);
+      return (
+        <Box padding={8} background="neutral100">
+          <Grid gap={2}>
+            {iconsArray.map((icon) => {
+              const Icon = Icons[icon];
+              return (
+                <GridItem padding={2} col={2} key={icon} background={'neutral0'}>
+                  <Box>
+                    <Icon aria-hidden={true} />
+                  </Box>
+                  <Box>
+                    <Text highlighted>{icon}</Text>
+                  </Box>
+                </GridItem>
+              );
+            })}
+          </Grid>
         </Box>
       );
     }}

--- a/packages/strapi-design-system/src/themes/Theme.stories.mdx
+++ b/packages/strapi-design-system/src/themes/Theme.stories.mdx
@@ -123,7 +123,6 @@ Description...
 <Canvas>
   <Story name="icons">
     {() => {
-      console.log('wtf', Icons);
       const iconsArray = Object.keys(Icons);
       return (
         <Box padding={8} background="neutral100">

--- a/packages/strapi-design-system/src/themes/Theme.stories.mdx
+++ b/packages/strapi-design-system/src/themes/Theme.stories.mdx
@@ -1,0 +1,60 @@
+<!--- TimePicker.stories.mdx --->
+
+import { useState } from 'react';
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Box } from '../Box';
+import { Grid, GridItem } from '../Grid';
+import { useTheme } from '../ThemeProvider';
+import { Stack } from '../Stack';
+
+<Meta title="Design System/Subatomic/LightTheme" component={Box} />
+
+# LightTheme
+
+This is the doc of the `TimePicker` component
+
+## LightTheme
+
+Description...
+
+<Canvas>
+  <Story name="colors">
+    {() => {
+      const theme = useTheme();
+      /* Excluding warning since they don't have enough contrast on for neutral900 and neutral0 */
+      const colorsKey = Object.keys(theme.colors).filter((color) => !color.includes('warning'));
+      const colors = [];
+      let ruptureKey;
+      for (const colorKey of colorsKey) {
+        const prefix = colorKey.substr(0, 2);
+        if (ruptureKey !== prefix) {
+          colors.push([]);
+          ruptureKey = prefix;
+        }
+        colors[colors.length - 1].push(colorKey);
+      }
+      return (
+        <Box>
+          <Grid>
+            {colors.map((colorGroup, idx) => (
+              <GridItem key={`color-group-${idx}`} padding={4}>
+                <Stack size={2}>
+                  {colorGroup.map((color) => (
+                    <Box
+                      key={color}
+                      padding={3}
+                      background={color}
+                      color={['600', '700', '800', '900'].some((v) => color.includes(v)) ? 'neutral0' : 'neutral900'}
+                    >
+                      {color}
+                    </Box>
+                  ))}
+                </Stack>
+              </GridItem>
+            ))}
+          </Grid>
+        </Box>
+      );
+    }}
+  </Story>
+</Canvas>

--- a/packages/strapi-design-system/src/themes/Theme.stories.mdx
+++ b/packages/strapi-design-system/src/themes/Theme.stories.mdx
@@ -75,7 +75,7 @@ Description...
         <Box padding={8} background="neutral100">
           <Grid gap={4}>
             {shadows.map((shadow) => (
-              <GridItem padding={8} shadow={shadow} background="neutral0">
+              <GridItem padding={8} shadow={shadow} background="neutral0" col={3}>
                 {shadow}
               </GridItem>
             ))}


### PR DESCRIPTION
https://design-system-git-light-theme-tokens-strapijs.vercel.app/?path=/story/design-system-subatomic-lighttheme--colors

<img width="1920" alt="Screenshot 2021-07-01 at 15 00 31 (2)" src="https://user-images.githubusercontent.com/3874873/124128597-3c28b500-da7d-11eb-89e3-a0c010a20e24.png">
<img width="1920" alt="Screenshot 2021-07-01 at 15 00 43 (2)" src="https://user-images.githubusercontent.com/3874873/124128662-48ad0d80-da7d-11eb-83f1-726775ab4a6b.png">
<img width="1920" alt="Screenshot 2021-07-01 at 14 59 45 (2)" src="https://user-images.githubusercontent.com/3874873/124128718-52cf0c00-da7d-11eb-8807-f8212ec84b4f.png">
<img width="1920" alt="Screenshot 2021-07-01 at 15 00 57 (2)" src="https://user-images.githubusercontent.com/3874873/124128764-60849180-da7d-11eb-8bb2-636ec096d883.png">
