### PR TITLE
Modify header layout for title and subtitle props

### DIFF
--- a/packages/strapi-design-system/src/Button/Button.js
+++ b/packages/strapi-design-system/src/Button/Button.js
@@ -32,6 +32,8 @@ export const ButtonWrapper = styled(BaseButton)`
     ${getActiveStyle}
   }
   ${getVariantStyle}
+
+  box-shadow: ${({ theme, withShadow }) => (withShadow ? theme.shadows.tableShadow : undefined)};
 `;
 
 export const Button = React.forwardRef(({ variant, startIcon, endIcon, disabled, children, size, ...props }, ref) => {

--- a/packages/strapi-design-system/src/HeaderLayout/HeaderLayout.js
+++ b/packages/strapi-design-system/src/HeaderLayout/HeaderLayout.js
@@ -1,9 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { H1, Subtitle, Text, H2 } from '../Text';
 import { Box } from '../Box';
 import { Row } from '../Row';
 
-export const HeaderLayout = ({ navigationAction, primaryAction, secondaryAction, subtitle, title, sticky }) => {
+export const HeaderLayout = ({
+  navigationAction,
+  primaryAction,
+  secondaryAction,
+  subtitle,
+  title,
+  sticky,
+  ...props
+}) => {
   if (sticky) {
     return (
       <Box paddingLeft={6} paddingRight={6} paddingTop={3} paddingBottom={3}>
@@ -11,8 +20,12 @@ export const HeaderLayout = ({ navigationAction, primaryAction, secondaryAction,
           <Row>
             <Box paddingRight={3}>{navigationAction}</Box>
             <Box>
-              {title}
-              {subtitle}
+              <H2 as="h1" {...props}>
+                {title}
+              </H2>
+              <Text small={true} textColor="neutral600">
+                {subtitle}
+              </Text>
             </Box>
           </Row>
           <Row>
@@ -29,12 +42,12 @@ export const HeaderLayout = ({ navigationAction, primaryAction, secondaryAction,
       {navigationAction ? <Box paddingBottom={3}>{navigationAction}</Box> : null}
       <Row justifyContent="space-between">
         <Row>
-          {title}
+          <H1 {...props}>{title}</H1>
           {secondaryAction ? <Box paddingLeft={4}>{secondaryAction}</Box> : null}
         </Row>
         {primaryAction}
       </Row>
-      {subtitle}
+      <Subtitle textColor="neutral600">{subtitle}</Subtitle>
     </Box>
   );
 };
@@ -52,6 +65,6 @@ HeaderLayout.propTypes = {
   primaryAction: PropTypes.node,
   secondaryAction: PropTypes.node,
   sticky: PropTypes.bool,
-  subtitle: PropTypes.node,
-  title: PropTypes.node.isRequired,
+  subtitle: PropTypes.string,
+  title: PropTypes.string.isRequired,
 };

--- a/packages/strapi-design-system/src/HeaderLayout/HeaderLayout.stories.mdx
+++ b/packages/strapi-design-system/src/HeaderLayout/HeaderLayout.stories.mdx
@@ -6,7 +6,6 @@ import EditIcon from '@strapi/icons/EditIcon';
 import AddIcon from '@strapi/icons/AddIcon';
 import { HeaderLayout } from './HeaderLayout';
 import { Link } from '../Link';
-import { Subtitle, H1, H2, Text } from '../Text';
 import { Button } from '../Button';
 import { Box } from '../Box';
 import { VisuallyHidden } from '../VisuallyHidden';
@@ -27,12 +26,13 @@ Description...
       <HeaderLayout
         primaryAction={<Button startIcon={<AddIcon />}>Add an entry</Button>}
         secondaryAction={
-          <Button variant="tertiary" startIcon={<EditIcon />}>
+          <Button variant="tertiary" withShadow startIcon={<EditIcon />}>
             Edit
           </Button>
         }
-        title={<H1 as="h2">Other CT</H1>}
-        subtitle={<Subtitle textColor="neutral600">36 entries found</Subtitle>}
+        title="Other CT"
+        subtitle="36 entries found"
+        as="h2"
       />
       <HeaderLayout
         navigationAction={
@@ -42,12 +42,13 @@ Description...
         }
         primaryAction={<Button startIcon={<AddIcon />}>Add an entry</Button>}
         secondaryAction={
-          <Button variant="tertiary" startIcon={<EditIcon />}>
+          <Button variant="tertiary" withShadow startIcon={<EditIcon />}>
             Edit
           </Button>
         }
-        title={<H1 as="h2">Restaurants</H1>}
-        subtitle={<Subtitle textColor="neutral600">36 entries found</Subtitle>}
+        title="Restaurants"
+        subtitle="36 entries found"
+        as="h2"
       />
     </Box>
   </Story>
@@ -69,16 +70,13 @@ Description...
         }
         primaryAction={<Button startIcon={<AddIcon />}>Add an entry</Button>}
         secondaryAction={
-          <Button variant="tertiary" startIcon={<EditIcon />}>
+          <Button variant="tertiary" startIcon={<EditIcon />} withShadow>
             Edit
           </Button>
         }
-        title={<H2>Restaurants</H2>}
-        subtitle={
-          <Text small={true} textColor="neutral600">
-            36 entries found
-          </Text>
-        }
+        title="Restaurants"
+        subtitle="36 entries found"
+        as="h2"
       />
     </Box>
   </Story>

--- a/packages/strapi-design-system/src/HeaderLayout/__tests__/HeaderLayout.spec.js
+++ b/packages/strapi-design-system/src/HeaderLayout/__tests__/HeaderLayout.spec.js
@@ -19,6 +19,24 @@ describe('HeaderLayout', () => {
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
+      .c4 {
+        font-weight: 600;
+        font-size: 2rem;
+        line-height: 1.25;
+      }
+
+      .c6 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #666687;
+      }
+
+      .c7 {
+        font-size: 1rem;
+        line-height: 1.5;
+      }
+
       .c0 {
         padding-top: 24px;
         padding-right: 56px;
@@ -30,7 +48,7 @@ describe('HeaderLayout', () => {
         padding-bottom: 12px;
       }
 
-      .c4 {
+      .c5 {
         padding-left: 16px;
       }
 
@@ -84,11 +102,15 @@ describe('HeaderLayout', () => {
           <div
             class="c3"
           >
-            <h2>
-              CT
-            </h2>
-            <div
+            <h1
               class="c4"
+            >
+              <h2>
+                CT
+              </h2>
+            </h1>
+            <div
+              class="c5"
             >
               <button>
                 secondary action
@@ -99,8 +121,12 @@ describe('HeaderLayout', () => {
             primary aciton
           </button>
         </div>
-        <p>
-          36 entries found
+        <p
+          class="c6 c7"
+        >
+          <p>
+            36 entries found
+          </p>
         </p>
       </div>
     `);
@@ -121,6 +147,19 @@ describe('HeaderLayout', () => {
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
+      .c4 {
+        font-weight: 600;
+        font-size: 1.125rem;
+        line-height: 1.22;
+      }
+
+      .c5 {
+        font-weight: 400;
+        font-size: 0.75rem;
+        line-height: 1.33;
+        color: #666687;
+      }
+
       .c0 {
         padding-top: 12px;
         padding-right: 24px;
@@ -132,7 +171,7 @@ describe('HeaderLayout', () => {
         padding-right: 12px;
       }
 
-      .c4 {
+      .c6 {
         padding-left: 8px;
       }
 
@@ -189,11 +228,19 @@ describe('HeaderLayout', () => {
             <div
               class=""
             >
-              <h2>
-                CT
-              </h2>
-              <p>
-                36 entries found
+              <h1
+                class="c4"
+              >
+                <h2>
+                  CT
+                </h2>
+              </h1>
+              <p
+                class="c5"
+              >
+                <p>
+                  36 entries found
+                </p>
               </p>
             </div>
           </div>
@@ -204,7 +251,7 @@ describe('HeaderLayout', () => {
               secondary action
             </button>
             <div
-              class="c4"
+              class="c6"
             >
               <button>
                 primary aciton

--- a/packages/strapi-design-system/src/HeaderLayout/__tests__/HeaderLayout.spec.js
+++ b/packages/strapi-design-system/src/HeaderLayout/__tests__/HeaderLayout.spec.js
@@ -12,8 +12,8 @@ describe('HeaderLayout', () => {
           navigationAction={<a href="/">Go back</a>}
           primaryAction={<button>primary aciton</button>}
           secondaryAction={<button>secondary action</button>}
-          title={<h2>CT</h2>}
-          subtitle={<p>36 entries found</p>}
+          title="CT"
+          subtitle="36 entries found"
         />
       </ThemeProvider>,
     );
@@ -105,9 +105,7 @@ describe('HeaderLayout', () => {
             <h1
               class="c4"
             >
-              <h2>
-                CT
-              </h2>
+              CT
             </h1>
             <div
               class="c5"
@@ -124,9 +122,7 @@ describe('HeaderLayout', () => {
         <p
           class="c6 c7"
         >
-          <p>
-            36 entries found
-          </p>
+          36 entries found
         </p>
       </div>
     `);
@@ -139,8 +135,8 @@ describe('HeaderLayout', () => {
           navigationAction={<a href="/">Go back</a>}
           primaryAction={<button>primary aciton</button>}
           secondaryAction={<button>secondary action</button>}
-          title={<h2>CT</h2>}
-          subtitle={<p>36 entries found</p>}
+          title={'CT'}
+          subtitle={'36 entries found'}
           sticky
         />
       </ThemeProvider>,
@@ -231,16 +227,12 @@ describe('HeaderLayout', () => {
               <h1
                 class="c4"
               >
-                <h2>
-                  CT
-                </h2>
+                CT
               </h1>
               <p
                 class="c5"
               >
-                <p>
-                  36 entries found
-                </p>
+                36 entries found
               </p>
             </div>
           </div>


### PR DESCRIPTION
- title and subtitle props are now string to enforce H1 tag on this header
- add a shadow on the button to create the effect wanted in figma for the tertiary button


UI doesn't change that much except for the shadow

