### PR TITLE
Text and paragraph

### DIFF
--- a/packages/strapi-design-system/src/Accordion/AccordionToggle.js
+++ b/packages/strapi-design-system/src/Accordion/AccordionToggle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import DropdownIcon from '@strapi/icons/FilterDropdown';
 import styled from 'styled-components';
-import { H3, Text } from '../Text';
+import { H3, P } from '../Text';
 import { useAccordion } from './AccordionContext';
 import { Box } from '../Box';
 import { Row } from '../Row';
@@ -55,9 +55,9 @@ export const AccordionToggle = ({ title, description, as, variant, togglePositio
                 </H3>
 
                 {description && (
-                  <Text id={ariaDescriptionId} textColor={descriptionColor}>
+                  <P id={ariaDescriptionId} textColor={descriptionColor}>
                     {description}
-                  </Text>
+                  </P>
                 )}
               </Box>
             </Row>
@@ -85,9 +85,9 @@ export const AccordionToggle = ({ title, description, as, variant, togglePositio
             </H3>
 
             {description && (
-              <Text id={ariaDescriptionId} textColor={descriptionColor}>
+              <P id={ariaDescriptionId} textColor={descriptionColor}>
                 {description}
-              </Text>
+              </P>
             )}
           </Box>
 

--- a/packages/strapi-design-system/src/Alert/Alert.js
+++ b/packages/strapi-design-system/src/Alert/Alert.js
@@ -6,7 +6,7 @@ import AlertSucessIcon from '@strapi/icons/AlertSucessIcon';
 import AlertWarningIcon from '@strapi/icons/AlertWarningIcon';
 import CloseAlertIcon from '@strapi/icons/CloseAlertIcon';
 import { Box } from '../Box';
-import { Text } from '../Text';
+import { Text, P } from '../Text';
 import { Row } from '../Row';
 import { handleBackgroundColor, handleBorderColor, handleIconColor } from './utils';
 
@@ -80,7 +80,7 @@ export const Alert = ({ title, children, variant, onClose, closeLabel, titleAs, 
           </Box>
 
           <Box paddingBottom={action ? 2 : 5} paddingRight={2}>
-            <Text textColor="neutral800">{children}</Text>
+            <P textColor="neutral800">{children}</P>
           </Box>
 
           {action && (

--- a/packages/strapi-design-system/src/Badge/__tests__/Badge.spec.js
+++ b/packages/strapi-design-system/src/Badge/__tests__/Badge.spec.js
@@ -45,11 +45,11 @@ describe('Badge', () => {
       <div
         class="c0 c1"
       >
-        <p
+        <span
           class="c2 c3 c4"
         >
           Doc
-        </p>
+        </span>
       </div>
     `);
   });

--- a/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.spec.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/__tests__/Breadcrumbs.spec.js
@@ -80,12 +80,12 @@ describe('Breadcrumbs', () => {
           <li
             class="c1 c2"
           >
-            <p
+            <span
               class="c3"
               color="neutral800"
             >
               Home
-            </p>
+            </span>
             <div
               class="c4 c5"
             >
@@ -106,12 +106,12 @@ describe('Breadcrumbs', () => {
           <li
             class="c1 c2"
           >
-            <p
+            <span
               class="c3"
               color="neutral800"
             >
               first
-            </p>
+            </span>
             <div
               class="c4 c5"
             >
@@ -132,12 +132,12 @@ describe('Breadcrumbs', () => {
           <li
             class="c1 c2"
           >
-            <p
+            <span
               class="c3"
               color="neutral800"
             >
               second
-            </p>
+            </span>
             <div
               class="c4 c5"
             >

--- a/packages/strapi-design-system/src/Button/Button.js
+++ b/packages/strapi-design-system/src/Button/Button.js
@@ -50,7 +50,7 @@ export const Button = React.forwardRef(({ variant, startIcon, endIcon, disabled,
           {children}
         </Text>
       ) : (
-        <TextButton as="span">{children}</TextButton>
+        <TextButton>{children}</TextButton>
       )}
 
       {endIcon && (

--- a/packages/strapi-design-system/src/Button/Button.js
+++ b/packages/strapi-design-system/src/Button/Button.js
@@ -46,7 +46,7 @@ export const Button = React.forwardRef(({ variant, startIcon, endIcon, disabled,
       )}
 
       {size === 's' ? (
-        <Text small={size === 'S'} as="span" highlighted>
+        <Text small={size === 'S'} highlighted>
           {children}
         </Text>
       ) : (

--- a/packages/strapi-design-system/src/Card/__tests__/Card.spec.js
+++ b/packages/strapi-design-system/src/Card/__tests__/Card.spec.js
@@ -292,11 +292,11 @@ describe('Card', () => {
           <time
             class="c8 c9"
           >
-            <p
+            <span
               class="c10"
             >
               05:39
-            </p>
+            </span>
           </time>
         </div>
         <div
@@ -323,11 +323,11 @@ describe('Card', () => {
             <div
               class="c15 c16 c17"
             >
-              <p
+              <span
                 class="c18 c19 c20"
               >
                 Doc
-              </p>
+              </span>
             </div>
           </div>
         </div>

--- a/packages/strapi-design-system/src/Carousel/__tests__/Carousel.spec.js
+++ b/packages/strapi-design-system/src/Carousel/__tests__/Carousel.spec.js
@@ -158,11 +158,11 @@ describe('Carousel', () => {
         <div
           class="c0"
         >
-          <p
+          <span
             class="c1"
           >
             Carousel of numbers (2/3)
-          </p>
+          </span>
         </div>
         <div
           class="c2"

--- a/packages/strapi-design-system/src/DatePicker/DatePickerTd.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePickerTd.js
@@ -30,7 +30,7 @@ export const DatePickerTd = ({ children, outsideMonth, onSelectDay, isSelected, 
   return (
     <RawTd {...props}>
       <DatePickerCellButton tabIndex={-1} onClick={onSelectDay} isSelected={isSelected}>
-        <Text small textColor={textColor} as="span">
+        <Text small textColor={textColor}>
           {children}
         </Text>
       </DatePickerCellButton>

--- a/packages/strapi-design-system/src/DatePicker/DatePickerTh.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePickerTh.js
@@ -21,7 +21,7 @@ export const DatePickerTh = ({ children, ...props }) => {
   return (
     <DatePickerThWrapper {...props}>
       <DatePickerThRow justifyContent="center">
-        <Text small highlighted={true} color="neutral800" aria-hidden as="span">
+        <Text small highlighted={true} color="neutral800" aria-hidden>
           {children.substr(0, 2)}
         </Text>
 

--- a/packages/strapi-design-system/src/Field/FieldError.js
+++ b/packages/strapi-design-system/src/Field/FieldError.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useField } from './FieldContext';
-import { Text } from '../Text';
+import { P } from '../Text';
 
 export const FieldError = () => {
   const { id, error } = useField();
@@ -10,8 +10,8 @@ export const FieldError = () => {
   }
 
   return (
-    <Text small={true} id={`field-error-${id}`} textColor="danger600">
+    <P small={true} id={`field-error-${id}`} textColor="danger600">
       {error}
-    </Text>
+    </P>
   );
 };

--- a/packages/strapi-design-system/src/Field/FieldHint.js
+++ b/packages/strapi-design-system/src/Field/FieldHint.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useField } from './FieldContext';
-import { Text } from '../Text';
+import { P } from '../Text';
 
 export const FieldHint = () => {
   const { id, hint, error } = useField();
@@ -10,8 +10,8 @@ export const FieldHint = () => {
   }
 
   return (
-    <Text small={true} id={`field-hint-${id}`} textColor="neutral600">
+    <P small={true} id={`field-hint-${id}`} textColor="neutral600">
       {hint}
-    </Text>
+    </P>
   );
 };

--- a/packages/strapi-design-system/src/HeaderLayout/HeaderLayout.js
+++ b/packages/strapi-design-system/src/HeaderLayout/HeaderLayout.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { H1, Subtitle, Text, H2 } from '../Text';
+import { H1, Subtitle, P, H2 } from '../Text';
 import { Box } from '../Box';
 import { Row } from '../Row';
 
@@ -23,9 +23,9 @@ export const HeaderLayout = ({
               <H2 as="h1" {...props}>
                 {title}
               </H2>
-              <Text small={true} textColor="neutral600">
+              <P small={true} textColor="neutral600">
                 {subtitle}
-              </Text>
+              </P>
             </Box>
           </Row>
           <Row>
@@ -47,7 +47,9 @@ export const HeaderLayout = ({
         </Row>
         {primaryAction}
       </Row>
-      <Subtitle textColor="neutral600">{subtitle}</Subtitle>
+      <Subtitle textColor="neutral600" as="p">
+        {subtitle}
+      </Subtitle>
     </Box>
   );
 };

--- a/packages/strapi-design-system/src/Link/Link.js
+++ b/packages/strapi-design-system/src/Link/Link.js
@@ -44,9 +44,7 @@ export const Link = ({ href, to, children, disabled, startIcon, endIcon, ...prop
         </IconWrapper>
       )}
 
-      <TableLabel textColor={disabled ? 'neutral600' : 'primary600'} as="span">
-        {children}
-      </TableLabel>
+      <TableLabel textColor={disabled ? 'neutral600' : 'primary600'}>{children}</TableLabel>
 
       {endIcon && !href && (
         <IconWrapper as="span" aria-hidden={true} paddingLeft={2}>

--- a/packages/strapi-design-system/src/MainNav/NavBrand.js
+++ b/packages/strapi-design-system/src/MainNav/NavBrand.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Box } from '../Box';
-import { Text, TextButton } from '../Text';
+import { P, TextButton } from '../Text';
 import { Row } from '../Row';
 import { useMainNav } from './MainNavContext';
 import { VisuallyHidden } from '../VisuallyHidden';
@@ -43,9 +43,9 @@ export const NavBrand = ({ workplace, title, icon }) => {
 
         <Box paddingLeft={2}>
           <TextButton textColor="neutral800">{title}</TextButton>
-          <Text small textColor="neutral600">
+          <P small textColor="neutral600">
             {workplace}
-          </Text>
+          </P>
         </Box>
       </Row>
     </Box>

--- a/packages/strapi-design-system/src/MainNav/NavLink.js
+++ b/packages/strapi-design-system/src/MainNav/NavLink.js
@@ -66,7 +66,7 @@ export const NavLink = ({ children, icon, active, ...props }) => {
             {icon}
           </IconBox>
 
-          <Text as="span" textColor={active ? 'primary600' : 'neutral600'} highlighted={active}>
+          <Text textColor={active ? 'primary600' : 'neutral600'} highlighted={active}>
             {children}
           </Text>
         </MainNavRow>

--- a/packages/strapi-design-system/src/MainNav/NavSection.js
+++ b/packages/strapi-design-system/src/MainNav/NavSection.js
@@ -40,9 +40,7 @@ export const NavSection = ({ label, ...props }) => {
           hasRadius
           as="span"
         >
-          <TableLabel as="span" textColor="neutral600">
-            {label}
-          </TableLabel>
+          <TableLabel textColor="neutral600">{label}</TableLabel>
         </Box>
 
         <Stack as="ul" size={2} {...props}></Stack>

--- a/packages/strapi-design-system/src/MainNav/NavUser.js
+++ b/packages/strapi-design-system/src/MainNav/NavUser.js
@@ -28,9 +28,7 @@ export const NavUser = ({ src, children, ...props }) => {
           </VisuallyHidden>
         ) : (
           <Box paddingLeft={2} as="span">
-            <Text as="span" textColor="neutral600">
-              {children}
-            </Text>
+            <Text textColor="neutral600">{children}</Text>
           </Box>
         )}
       </Row>

--- a/packages/strapi-design-system/src/MainNav/__tests__/MainNav.spec.js
+++ b/packages/strapi-design-system/src/MainNav/__tests__/MainNav.spec.js
@@ -276,11 +276,11 @@ describe('MainNav', () => {
             <div
               class="c4"
             >
-              <p
+              <span
                 class="c5 c6 c7"
               >
                 Strapi Dashboard
-              </p>
+              </span>
               <p
                 class="c5 c8"
               >

--- a/packages/strapi-design-system/src/Pagination/__tests__/Pagination.spec.js
+++ b/packages/strapi-design-system/src/Pagination/__tests__/Pagination.spec.js
@@ -193,12 +193,12 @@ describe('Pagination', () => {
               >
                 Page 1
               </div>
-              <p
+              <span
                 aria-hidden="true"
                 class="c7 c8"
               >
                 1
-              </p>
+              </span>
             </a>
           </li>
           <li>
@@ -212,12 +212,12 @@ describe('Pagination', () => {
               >
                 Page 2
               </div>
-              <p
+              <span
                 aria-hidden="true"
                 class="c10 c8"
               >
                 2
-              </p>
+              </span>
             </a>
           </li>
           <li>
@@ -231,12 +231,12 @@ describe('Pagination', () => {
               >
                 Page 3
               </div>
-              <p
+              <span
                 aria-hidden="true"
                 class="c10 c8"
               >
                 3
-              </p>
+              </span>
             </a>
           </li>
           <li>
@@ -248,12 +248,12 @@ describe('Pagination', () => {
               >
                 There are pages in between
               </div>
-              <p
+              <span
                 aria-hidden="true"
                 class="c10 c8"
               >
                 …
-              </p>
+              </span>
             </div>
           </li>
           <li>
@@ -267,12 +267,12 @@ describe('Pagination', () => {
               >
                 Page 4
               </div>
-              <p
+              <span
                 aria-hidden="true"
                 class="c10 c8"
               >
                 4
-              </p>
+              </span>
             </a>
           </li>
           <li>
@@ -491,12 +491,12 @@ describe('Pagination', () => {
               >
                 Page 1
               </div>
-              <p
+              <span
                 aria-hidden="true"
                 class="c6 c7"
               >
                 1
-              </p>
+              </span>
             </a>
           </li>
           <li>
@@ -510,12 +510,12 @@ describe('Pagination', () => {
               >
                 Page 2
               </div>
-              <p
+              <span
                 aria-hidden="true"
                 class="c6 c7"
               >
                 2
-              </p>
+              </span>
             </a>
           </li>
           <li>
@@ -529,12 +529,12 @@ describe('Pagination', () => {
               >
                 Page 3
               </div>
-              <p
+              <span
                 aria-hidden="true"
                 class="c6 c7"
               >
                 3
-              </p>
+              </span>
             </a>
           </li>
           <li>
@@ -546,12 +546,12 @@ describe('Pagination', () => {
               >
                 There are pages in between
               </div>
-              <p
+              <span
                 aria-hidden="true"
                 class="c6 c7"
               >
                 …
-              </p>
+              </span>
             </div>
           </li>
           <li>
@@ -565,12 +565,12 @@ describe('Pagination', () => {
               >
                 Page 4
               </div>
-              <p
+              <span
                 aria-hidden="true"
                 class="c11 c7"
               >
                 4
-              </p>
+              </span>
             </a>
           </li>
           <li>

--- a/packages/strapi-design-system/src/Select/Option.js
+++ b/packages/strapi-design-system/src/Select/Option.js
@@ -64,7 +64,7 @@ export const Option = ({ selected, children, value, multi, ...props }) => {
             <CheckMark selected={selected} />
           </Box>
         )}
-        <Text as="span" textColor={selected ? 'primary600' : 'neutral800'} highlighted={selected}>
+        <Text textColor={selected ? 'primary600' : 'neutral800'} highlighted={selected}>
           {children}
         </Text>
       </Row>

--- a/packages/strapi-design-system/src/Select/Select.js
+++ b/packages/strapi-design-system/src/Select/Select.js
@@ -144,7 +144,7 @@ export const Select = ({
                 {withTags ? (
                   <>
                     {!value || value.length === 0 ? (
-                      <Text id={contentId} as="span" textColor={'neutral600'}>
+                      <Text id={contentId} textColor={'neutral600'}>
                         {placeholder}
                       </Text>
                     ) : null}
@@ -154,7 +154,7 @@ export const Select = ({
                     </VisuallyHidden>
                   </>
                 ) : (
-                  <Text id={contentId} as="span" textColor={value ? 'neutral800' : 'neutral600'}>
+                  <Text id={contentId} textColor={value ? 'neutral800' : 'neutral600'}>
                     {customizeContent ? customizeContent(value) : selectOptionLabel || placeholder}
                     {multi && <VisuallyHidden as="span">{value.join(', ')}</VisuallyHidden>}
                   </Text>

--- a/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
+++ b/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
@@ -63,13 +63,13 @@ export const MenuItem = ({ children, onClick, href, isFocused, ...props }) => {
       {href ? (
         <OptionLink href={href} {...menuItemProps}>
           <Box padding={2}>
-            <Text as="span">{children}</Text>
+            <Text>{children}</Text>
           </Box>
         </OptionLink>
       ) : (
         <OptionButton onKeyDown={handleKeyDown} onMouseDown={onClick} {...menuItemProps}>
           <Box padding={2}>
-            <Text as="span">{children}</Text>
+            <Text>{children}</Text>
           </Box>
         </OptionButton>
       )}
@@ -159,7 +159,7 @@ export const SimpleMenu = ({ label, children, ...props }) => {
         {...props}
       >
         <Box paddingRight={1}>
-          <TextButton as="span">{label}</TextButton>
+          <TextButton>{label}</TextButton>
         </Box>
         <FilterDropdown aria-hidden />
       </MenuButton>

--- a/packages/strapi-design-system/src/Status/Status.stories.mdx
+++ b/packages/strapi-design-system/src/Status/Status.stories.mdx
@@ -20,18 +20,12 @@ Description...
     <Stack size={3}>
       <Status variant="success">
         <Text>
-          Hello world{' '}
-          <Text as="span" highlighted>
-            thing happens
-          </Text>
+          Hello world <Text highlighted>thing happens</Text>
         </Text>
       </Status>
       <Status variant="secondary">
         <Text>
-          Hello world{' '}
-          <Text as="span" highlighted>
-            thing happens
-          </Text>
+          Hello world <Text highlighted>thing happens</Text>
         </Text>
       </Status>
     </Stack>

--- a/packages/strapi-design-system/src/Status/__tests__/Status.spec.js
+++ b/packages/strapi-design-system/src/Status/__tests__/Status.spec.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { Status } from '../Status';
-import { Text } from '../../Text';
+import { Text, P } from '../../Text';
 import { ThemeProvider } from '../../ThemeProvider';
 import { lightTheme } from '../../themes';
 
@@ -10,12 +10,9 @@ describe('Status', () => {
     const { container } = render(
       <ThemeProvider theme={lightTheme}>
         <Status variant="primary">
-          <Text>
-            Hello world{' '}
-            <Text as="span" highlighted>
-              thing happens
-            </Text>
-          </Text>
+          <P>
+            Hello world <Text highlighted>thing happens</Text>
+          </P>
         </Status>
       </ThemeProvider>,
     );
@@ -81,8 +78,7 @@ describe('Status', () => {
           <p
             class="c4 c5"
           >
-            Hello world
-             
+            Hello world 
             <span
               class="c4 c6"
             >

--- a/packages/strapi-design-system/src/SubNav/__tests__/SubNav.spec.js
+++ b/packages/strapi-design-system/src/SubNav/__tests__/SubNav.spec.js
@@ -504,11 +504,11 @@ describe('SubNav', () => {
                     <div
                       class="c16"
                     >
-                      <p
+                      <span
                         class="c17 c18 c19 c20"
                       >
                         Collection Type
-                      </p>
+                      </span>
                     </div>
                     <div
                       class="c21"
@@ -533,11 +533,11 @@ describe('SubNav', () => {
                   <div
                     class="c22 c23 c24"
                   >
-                    <p
+                    <span
                       class="c17 c25 c19 c20"
                     >
                       4
-                    </p>
+                    </span>
                   </div>
                 </div>
               </div>
@@ -705,11 +705,11 @@ describe('SubNav', () => {
                     <div
                       class="c16"
                     >
-                      <p
+                      <span
                         class="c17 c18 c19 c20"
                       >
                         Single Type
-                      </p>
+                      </span>
                     </div>
                     <div
                       class="c21"
@@ -734,11 +734,11 @@ describe('SubNav', () => {
                   <div
                     class="c22 c23 c24"
                   >
-                    <p
+                    <span
                       class="c17 c25 c19 c20"
                     >
                       4
-                    </p>
+                    </span>
                   </div>
                 </div>
               </div>

--- a/packages/strapi-design-system/src/Table/TFooter.js
+++ b/packages/strapi-design-system/src/Table/TFooter.js
@@ -42,7 +42,7 @@ export const TFooter = ({ children, icon, ...props }) => {
             {icon}
           </IconBox>
           <Box paddingLeft={3}>
-            <Text small={true} highlighted={true} textColor="primary600" as="span">
+            <Text small={true} highlighted={true} textColor="primary600">
               {children}
             </Text>
           </Box>

--- a/packages/strapi-design-system/src/Table/Table.stories.mdx
+++ b/packages/strapi-design-system/src/Table/Table.stories.mdx
@@ -56,19 +56,19 @@ Description...
                   <BaseCheckbox aria-label="Select all entries" />
                 </Th>
                 <Th>
-                  <TableLabel as="span">ID</TableLabel>
+                  <TableLabel>ID</TableLabel>
                 </Th>
                 <Th>
-                  <TableLabel as="span">Cover</TableLabel>
+                  <TableLabel>Cover</TableLabel>
                 </Th>
                 <Th>
-                  <TableLabel as="span">Description</TableLabel>
+                  <TableLabel>Description</TableLabel>
                 </Th>
                 <Th>
-                  <TableLabel as="span">Categories</TableLabel>
+                  <TableLabel>Categories</TableLabel>
                 </Th>
                 <Th>
-                  <TableLabel as="span">Contact</TableLabel>
+                  <TableLabel>Contact</TableLabel>
                 </Th>
                 <Th>More</Th>
                 <Th>More</Th>
@@ -85,42 +85,28 @@ Description...
                     <BaseCheckbox aria-label={`Select ${entry.contact}`} />
                   </Td>
                   <Td>
-                    <Text textColor="neutral800" as="span">
-                      {entry.id}
-                    </Text>
+                    <Text textColor="neutral800">{entry.id}</Text>
                   </Td>
                   <Td>
                     <Avatar src={entry.cover} alt={entry.contact} />
                   </Td>
                   <Td>
-                    <Text textColor="neutral800" as="span">
-                      {entry.description}
-                    </Text>
+                    <Text textColor="neutral800">{entry.description}</Text>
                   </Td>
                   <Td>
-                    <Text textColor="neutral800" as="span">
-                      {entry.category}
-                    </Text>
+                    <Text textColor="neutral800">{entry.category}</Text>
                   </Td>
                   <Td>
-                    <Text textColor="neutral800" as="span">
-                      {entry.contact}
-                    </Text>
+                    <Text textColor="neutral800">{entry.contact}</Text>
                   </Td>
                   <Td>
-                    <Text textColor="neutral600" as="span">
-                      {entry.description}
-                    </Text>
+                    <Text textColor="neutral800">{entry.description}</Text>
                   </Td>
                   <Td>
-                    <Text textColor="neutral800" as="span">
-                      {entry.description}
-                    </Text>
+                    <Text textColor="neutral800">{entry.description}</Text>
                   </Td>
                   <Td>
-                    <Text textColor="neutral800" as="span">
-                      {entry.description}
-                    </Text>
+                    <Text textColor="neutral800">{entry.description}</Text>
                   </Td>
                   <Td>
                     <Row>

--- a/packages/strapi-design-system/src/Table/__tests__/Table.spec.js
+++ b/packages/strapi-design-system/src/Table/__tests__/Table.spec.js
@@ -47,19 +47,19 @@ describe('Table', () => {
                 <BaseCheckbox aria-label="Select all entries" />
               </Th>
               <Th>
-                <TableLabel as="span">ID</TableLabel>
+                <TableLabel>ID</TableLabel>
               </Th>
               <Th>
-                <TableLabel as="span">Cover</TableLabel>
+                <TableLabel>Cover</TableLabel>
               </Th>
               <Th>
-                <TableLabel as="span">Description</TableLabel>
+                <TableLabel>Description</TableLabel>
               </Th>
               <Th>
-                <TableLabel as="span">Categories</TableLabel>
+                <TableLabel>Categories</TableLabel>
               </Th>
               <Th>
-                <TableLabel as="span">Contact</TableLabel>
+                <TableLabel>Contact</TableLabel>
               </Th>
               <Th>
                 <VisuallyHidden>Actions</VisuallyHidden>
@@ -73,27 +73,19 @@ describe('Table', () => {
                   <BaseCheckbox aria-label={`Select ${entry.contact}`} />
                 </Td>
                 <Td>
-                  <Text textColor="neutral600" as="span">
-                    {entry.id}
-                  </Text>
+                  <Text textColor="neutral600">{entry.id}</Text>
                 </Td>
                 <Td>
                   <Avatar src={entry.cover} alt={entry.contact} />
                 </Td>
                 <Td>
-                  <Text textColor="neutral600" as="span">
-                    {entry.description}
-                  </Text>
+                  <Text textColor="neutral600">{entry.description}</Text>
                 </Td>
                 <Td>
-                  <Text textColor="neutral600" as="span">
-                    {entry.category}
-                  </Text>
+                  <Text textColor="neutral600">{entry.category}</Text>
                 </Td>
                 <Td>
-                  <Text textColor="neutral600" as="span">
-                    {entry.contact}
-                  </Text>
+                  <Text textColor="neutral600">{entry.contact}</Text>
                 </Td>
                 <Td>
                   <IconButton onClick={() => console.log('edit')} label="Edit" noBorder icon={<EditIcon />} />

--- a/packages/strapi-design-system/src/Tabs/Tabs.js
+++ b/packages/strapi-design-system/src/Tabs/Tabs.js
@@ -113,9 +113,7 @@ export const Tab = ({ selected, id, children, ...props }) => {
       {...props}
     >
       <TabBox padding={selected ? 4 : 3} background={selected ? 'neutral0' : 'neutral100'} selected={selected}>
-        <TextButton as="span" textColor={selected ? 'primary700' : 'neutral600'}>
-          {children}
-        </TextButton>
+        <TextButton textColor={selected ? 'primary700' : 'neutral600'}>{children}</TextButton>
       </TabBox>
     </TabButton>
   );

--- a/packages/strapi-design-system/src/Text/__tests__/Text.spec.js
+++ b/packages/strapi-design-system/src/Text/__tests__/Text.spec.js
@@ -93,36 +93,36 @@ describe('Text', () => {
         >
           third title
         </h3>
-        <p
+        <span
           class="c3"
         >
           Text body
-        </p>
-        <p
+        </span>
+        <span
           class="c4"
         >
           Text body highlighted
-        </p>
-        <p
+        </span>
+        <span
           class="c5"
         >
           Text body small
-        </p>
-        <p
+        </span>
+        <span
           class="c6"
         >
           Small button text
-        </p>
-        <p
+        </span>
+        <span
           class="c3 c7"
         >
           Text button
-        </p>
-        <p
+        </span>
+        <span
           class="c3 c8"
         >
           Subtitle
-        </p>
+        </span>
       </div>
     `);
   });

--- a/packages/strapi-design-system/src/Text/index.js
+++ b/packages/strapi-design-system/src/Text/index.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import styled from 'styled-components';
 
 const handleColor = ({ theme, textColor }) => theme.colors[textColor];
@@ -34,12 +35,14 @@ const textStyles = {
   },
 };
 
-export const Text = styled.p`
+export const Text = styled.span`
   font-weight: ${({ highlighted }) => (highlighted ? 500 : 400)};
   font-size: ${({ small }) => textStyles[small ? 'S' : 'M'].fontSize};
   line-height: ${({ small }) => textStyles[small ? 'S' : 'M'].lineHeight};
   color: ${handleColor};
 `;
+
+export const P = (props) => <Text as="p" {...props} />;
 
 export const Subtitle = styled(Text)`
   font-size: 1rem;

--- a/packages/strapi-design-system/src/TextButton/TextButton.js
+++ b/packages/strapi-design-system/src/TextButton/TextButton.js
@@ -37,7 +37,7 @@ export const TextButton = React.forwardRef(({ children, startIcon, endIcon, onCl
           {startIcon}
         </Box>
       )}
-      <Text small={true} textColor={disabled ? 'neutral600' : 'primary600'} as="span">
+      <Text small={true} textColor={disabled ? 'neutral600' : 'primary600'}>
         {children}
       </Text>
       {endIcon && (

--- a/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.js
+++ b/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.js
@@ -63,7 +63,7 @@ export const ToggleCheckbox = React.forwardRef(({ onLabel, offLabel, children, c
           paddingTop={3}
           paddingBottom={3}
         >
-          <Text small={true} highlighted={true} as="span" textColor={checked ? labelColor : 'danger700'}>
+          <Text small={true} highlighted={true} textColor={checked ? labelColor : 'danger700'}>
             {offLabel}
           </Text>
         </OffBox>
@@ -75,7 +75,7 @@ export const ToggleCheckbox = React.forwardRef(({ onLabel, offLabel, children, c
           paddingTop={3}
           paddingBottom={3}
         >
-          <Text small={true} highlighted={true} as="span" textColor={checked ? 'primary700' : labelColor}>
+          <Text small={true} highlighted={true} textColor={checked ? 'primary700' : labelColor}>
             {onLabel}
           </Text>
         </OnBox>

--- a/packages/strapi-design-system/src/Tooltip/Tooltip.js
+++ b/packages/strapi-design-system/src/Tooltip/Tooltip.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Box } from '../Box';
-import { Text } from '../Text';
+import { P } from '../Text';
 import { Portal } from '../Portal';
 import { useTooltipHandlers } from './hooks/useTooltipHandlers';
 import { useTooltipLayout } from './hooks/useTooltipLayout';
@@ -41,9 +41,9 @@ export const Tooltip = ({ children, label, description, delay, position, ...prop
           {...props}
         >
           {visible && <VisuallyHidden id={descriptionId}>{description}</VisuallyHidden>}
-          <Text small={true} highlighted={true} textColor="neutral0">
+          <P small={true} highlighted={true} textColor="neutral0">
             {label || description}
-          </Text>
+          </P>
         </TooltipWrapper>
       </Portal>
 

--- a/packages/strapi-design-system/src/themes/Theme.stories.mdx
+++ b/packages/strapi-design-system/src/themes/Theme.stories.mdx
@@ -102,10 +102,7 @@ Description...
               <Row key={`space-${space}`}>
                 <Box background="primary500" hasRadius style={{ width: `${space * 4}px`, height: '4px' }} />
                 <Box paddingLeft={2}>
-                  <Text as="span">{space}</Text>{' '}
-                  <Text small as="span">
-                    ({space * 4}px)
-                  </Text>
+                  <Text>{space}</Text> <Text small>({space * 4}px)</Text>
                 </Box>
               </Row>
             ))}


### PR DESCRIPTION
Add a `Paragraph` component to prevent from doing `<Text as="span" />` everywhere (since `Text` was a `p` tag before)

Now:

- `Text` => `span`
- `Paragraph` => `p`