### PR TITLE
[DO NOT MERGE] Add sub nav to cra

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -9,6 +9,7 @@
     "@strapi/icons": "file:../packages/strapi-icons/dist",
     "jest-styled-components": "^7.0.4",
     "lodash": "^4.17.21",
+    "match-sorter": "^6.3.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",

--- a/example/src/layouts/OneBlockLayout.js
+++ b/example/src/layouts/OneBlockLayout.js
@@ -1,30 +1,33 @@
 import React from "react";
 import { Main, SkipToContent } from "@strapi/design-system/Main";
 import { Box } from "@strapi/design-system/Box";
+import { Row } from "@strapi/design-system/Row";
 import { Grid, GridItem } from "@strapi/design-system/Grid";
 import { SideNav } from "../shared/SideNav";
+import { SubSideNav } from "../shared/SubSideNav";
 
 export const OneBlockLayout = ({ children, header }) => {
   return (
     <Box background="neutral100">
       <SkipToContent>Skip to content</SkipToContent>
-
-      <Grid>
-        <GridItem col={2} hiddenS style={{ height: "100vh" }}>
+      <Row alignItems="flex-start">
+        <Row style={{ height: "100vh" }}>
           <SideNav />
-        </GridItem>
-        <GridItem col={10} s={12} paddingRight={[10, 0]}>
-          <Main labelledBy="main-title">
-            <Box paddingBottom={[8, 4]} paddingTop={[8, 4]}>
-              {header}
-            </Box>
-
-            <Box background="neutral0" shadow="filterShadow" hasRadius>
-              {children}
-            </Box>
-          </Main>
-        </GridItem>
-      </Grid>
+          <SubSideNav />
+        </Row>
+        <Grid style={{ flex: 1, alignSelf: "stretch" }}>
+          <GridItem col={12} paddingLeft={[10, 0]} paddingRight={[10, 0]}>
+            <Main labelledBy="main-title">
+              <Box paddingBottom={[8, 4]} paddingTop={[8, 4]}>
+                {header}
+              </Box>
+              <Box background="neutral0" shadow="filterShadow" hasRadius>
+                {children}
+              </Box>
+            </Main>
+          </GridItem>
+        </Grid>
+      </Row>
     </Box>
   );
 };

--- a/example/src/shared/SideNav.js
+++ b/example/src/shared/SideNav.js
@@ -22,12 +22,8 @@ export const SideNav = () => {
   const [condensed, setCondensed] = useState(false);
 
   return (
-    <MainNav condensed={condensed}>
-      <NavBrand
-        workplace="Workplace"
-        title="Strapi Dashboard"
-        icon={<img src={strapiImage} alt="" />}
-      />
+    <MainNav style={{ borderRight: "2px solid #EAEAEF" }} condensed={condensed}>
+      <NavBrand workplace="Workplace" title="Strapi Dashboard" icon={<img src={strapiImage} alt="" />} />
       <Divider />
       <NavSections>
         <NavLink href="/content" icon={<ContentIcon />}>
@@ -56,11 +52,7 @@ export const SideNav = () => {
           </NavLink>
         </NavSection>
       </NavSections>
-      <Divider />
-      <NavUser
-        src="https://avatars.githubusercontent.com/u/3874873?v=4"
-        href="/somewhere-i-belong"
-      >
+      <NavUser src="https://avatars.githubusercontent.com/u/3874873?v=4" href="/somewhere-i-belong">
         John Duff
       </NavUser>
       <NavCondense onClick={() => setCondensed((s) => !s)}>

--- a/example/src/shared/SubSideNav.js
+++ b/example/src/shared/SubSideNav.js
@@ -1,0 +1,56 @@
+import React from "react";
+import {
+  SubNav,
+  SubNavHeader,
+  SubNavSections,
+  SubNavSection,
+  SubNavLink,
+} from "@strapi/design-system/SubNav";
+import { Box } from "@strapi/design-system/Box";
+import { TextButton } from "@strapi/design-system/TextButton";
+import AddIcon from "@strapi/icons/AddIcon";
+import { cmData } from "./cmData";
+import { useSearch } from "./useSearch";
+
+export const SubSideNav = () => {
+  const { search, setSearch, searchResults } = useSearch(cmData, { keys: ["label"] });
+  const collectionType = searchResults.filter((link) => link.kind === "collectionType");
+  const singleType = searchResults.filter((link) => link.kind === "singleType");
+
+  return (
+    <SubNav ariaLabel="Builder sub nav">
+      <SubNavHeader
+        searchable
+        value={search}
+        onClear={() => setSearch("")}
+        onChange={(e) => setSearch(e.target.value)}
+        label="Builder"
+        searchLabel="Search..."
+      />
+      <SubNavSections>
+        <SubNavSection label="Collection Type" collapsable badgeLabel={collectionType.length.toString()}>
+          {collectionType &&
+            collectionType.map((link) => (
+              <SubNavLink href={link.to} active={link.active} key={link.id}>
+                {link.label}
+              </SubNavLink>
+            ))}
+        </SubNavSection>
+        <Box as="li" paddingLeft={7}>
+          <TextButton startIcon={<AddIcon />}>Click on me</TextButton>
+        </Box>
+        <SubNavSection label="Single Type" collapsable badgeLabel={singleType.length.toString()}>
+          {singleType &&
+            singleType.map((link) => (
+              <SubNavLink href={link.to} key={link.id}>
+                {link.label}
+              </SubNavLink>
+            ))}
+        </SubNavSection>
+        <Box as="li" paddingLeft={7}>
+          <TextButton startIcon={<AddIcon />}>Click on me</TextButton>
+        </Box>
+      </SubNavSections>
+    </SubNav>
+  );
+};

--- a/example/src/shared/cmData.js
+++ b/example/src/shared/cmData.js
@@ -1,0 +1,32 @@
+import AlertWarningIcon from "@strapi/icons/AlertWarningIcon";
+import Applications from "@strapi/icons/Applications";
+
+export const cmData = [
+  {
+    id: 1,
+    label: "Addresses",
+    icon: <AlertWarningIcon />,
+    to: "/address",
+    kind: "collectionType",
+  },
+  {
+    id: 2,
+    label: "Categories",
+    to: "/category",
+    kind: "collectionType",
+  },
+  {
+    id: 3,
+    label: "City",
+    icon: <Applications />,
+    to: "/city",
+    kind: "singleType",
+  },
+  {
+    id: 4,
+    label: "Countries",
+    to: "/country",
+    active: true,
+    kind: "singleType",
+  },
+];

--- a/example/src/shared/useSearch.js
+++ b/example/src/shared/useSearch.js
@@ -1,0 +1,12 @@
+import { useState } from "react";
+import {matchSorter} from 'match-sorter'
+
+export const useSearch = (items, searchOptions) => {
+  const [search, setSearch] = useState('');
+
+  return {
+    search,
+    setSearch,
+    searchResults: matchSorter(items, search, searchOptions),
+  };
+};

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -7125,6 +7125,14 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+match-sorter@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.0.tgz#454a1b31ed218cddbce6231a0ecb5fdc549fed01"
+  integrity sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -9369,6 +9377,11 @@ relateurl@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
+
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"

--- a/packages/strapi-design-system/src/IconButton/IconButton.js
+++ b/packages/strapi-design-system/src/IconButton/IconButton.js
@@ -30,9 +30,9 @@ const IconButtonWrapper = styled(BaseButton)`
   ${({ noBorder }) => (noBorder ? `border: none;` : undefined)}
 `;
 
-export const IconButton = React.forwardRef(({ label, noBorder, icon, ...props }, ref) => {
+export const IconButton = React.forwardRef(({ label, noBorder, icon, tooltipPosition, ...props }, ref) => {
   return (
-    <Tooltip label={label}>
+    <Tooltip label={label} position={tooltipPosition}>
       <IconButtonWrapper {...props} ref={ref} noBorder={noBorder}>
         {icon}
       </IconButtonWrapper>
@@ -46,9 +46,11 @@ IconButton.defaultProps = {
   title: undefined,
   noBorder: false,
   label: undefined,
+  tooltipPosition: 'top',
 };
 IconButton.propTypes = {
   icon: PropTypes.element.isRequired,
   label: PropTypes.string,
   noBorder: PropTypes.bool,
+  tooltipPosition: PropTypes.oneOf(['top', 'left', 'bottom', 'right']),
 };

--- a/packages/strapi-design-system/src/MainNav/MainNav.js
+++ b/packages/strapi-design-system/src/MainNav/MainNav.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { Grid } from '../Grid';
 import { MainNavContext } from './MainNavContext';
 
-const MainNavWrapper = styled(Grid)`
+const MainNavWrapper = styled.nav`
   width: ${({ condensed }) => (condensed ? 'max-content' : `${224 / 16}rem`)};
   background: ${({ theme }) => theme.colors.neutral0};
   height: 100%;
@@ -14,7 +13,7 @@ const MainNavWrapper = styled(Grid)`
 export const MainNav = ({ condensed, ...props }) => {
   return (
     <MainNavContext.Provider value={condensed}>
-      <MainNavWrapper as="nav" condensed={condensed} {...props} />
+      <MainNavWrapper condensed={condensed} {...props} />
     </MainNavContext.Provider>
   );
 };

--- a/packages/strapi-design-system/src/MainNav/MainNav.stories.mdx
+++ b/packages/strapi-design-system/src/MainNav/MainNav.stories.mdx
@@ -20,10 +20,7 @@ import { Box } from '../Box';
 import { Divider } from '../Divider';
 import strapiImage from './strapi-img.png';
 
-<Meta
-  title="Design System/Organisms/MainNav"
-  component={MainNav}
-/>
+<Meta title="Design System/Organisms/MainNav" component={MainNav} />
 
 # MainNav
 
@@ -69,7 +66,6 @@ Description...
                 </NavLink>
               </NavSection>
             </NavSections>
-            <Divider />
             <NavUser src="https://avatars.githubusercontent.com/u/3874873?v=4" href="/somewhere-i-belong">
               John Duff
             </NavUser>

--- a/packages/strapi-design-system/src/MainNav/NavCondense.js
+++ b/packages/strapi-design-system/src/MainNav/NavCondense.js
@@ -16,9 +16,10 @@ const NavCondenseWrapper = styled.button`
   display: flex;
   align-items: center;
   position: absolute;
-  bottom: ${({ theme }) => theme.spaces[3]};
+  bottom: ${({ theme }) => theme.spaces[2]};
   right: ${({ theme, condensed }) => (condensed ? 0 : theme.spaces[5])};
   transform: ${({ condensed }) => (condensed ? `translateX(50%)` : undefined)};
+  z-index: ${({ theme }) => theme.zIndices[0]};
 `;
 
 export const NavCondense = ({ children, ...props }) => {

--- a/packages/strapi-design-system/src/MainNav/NavUser.js
+++ b/packages/strapi-design-system/src/MainNav/NavUser.js
@@ -7,34 +7,42 @@ import { Row } from '../Row';
 import { Box } from '../Box';
 import { useMainNav } from './MainNavContext';
 import { VisuallyHidden } from '../VisuallyHidden';
+import { Divider } from '../Divider';
 
-const NavUserBox = styled(Box)`
-  text-decoration: none;
+const NavUserWrapper = styled.div`
   position: absolute;
   bottom: 0;
   width: 100%;
+`;
+const NavUserBox = styled(Box)`
+  display: block;
+  width: 100%;
+  text-decoration: none;
 `;
 
 export const NavUser = ({ src, children, ...props }) => {
   const condensed = useMainNav();
 
   return (
-    <NavUserBox paddingTop={3} paddingBottom={3} paddingLeft={5} paddingRight={5} as="a" {...props}>
-      <Row as="span" justifyContent={condensed ? 'center' : undefined}>
-        <Avatar src={src} alt="" aria-hidden />
-        {condensed ? (
-          <VisuallyHidden>
-            <span>{children}</span>
-          </VisuallyHidden>
-        ) : (
-          <Box paddingLeft={2} as="span">
-            <Text as="span" textColor="neutral600">
-              {children}
-            </Text>
-          </Box>
-        )}
-      </Row>
-    </NavUserBox>
+    <NavUserWrapper>
+      <Divider />
+      <NavUserBox paddingTop={3} paddingBottom={3} paddingLeft={5} paddingRight={5} as="a" {...props}>
+        <Row as="span" justifyContent={condensed ? 'center' : undefined}>
+          <Avatar src={src} alt="" aria-hidden />
+          {condensed ? (
+            <VisuallyHidden>
+              <span>{children}</span>
+            </VisuallyHidden>
+          ) : (
+            <Box paddingLeft={2} as="span">
+              <Text as="span" textColor="neutral600">
+                {children}
+              </Text>
+            </Box>
+          )}
+        </Row>
+      </NavUserBox>
+    </NavUserWrapper>
   );
 };
 

--- a/packages/strapi-design-system/src/MainNav/__tests__/MainNav.spec.js
+++ b/packages/strapi-design-system/src/MainNav/__tests__/MainNav.spec.js
@@ -61,6 +61,13 @@ describe('MainNav', () => {
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
+      .c0 {
+        width: 14rem;
+        background: #ffffff;
+        height: 100%;
+        position: relative;
+      }
+
       .c1 {
         padding-top: 16px;
         padding-right: 12px;
@@ -102,13 +109,6 @@ describe('MainNav', () => {
       .c24 {
         padding-top: 12px;
         padding-bottom: 12px;
-      }
-
-      .c0 {
-        width: 14rem;
-        background: #ffffff;
-        height: 100%;
-        position: relative;
       }
 
       .c6 {
@@ -585,6 +585,15 @@ describe('MainNav', () => {
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
+      .c0 {
+        width: -webkit-max-content;
+        width: -moz-max-content;
+        width: max-content;
+        background: #ffffff;
+        height: 100%;
+        position: relative;
+      }
+
       .c1 {
         padding-top: 16px;
         padding-right: 12px;
@@ -620,15 +629,6 @@ describe('MainNav', () => {
       .c17 {
         padding-top: 12px;
         padding-bottom: 12px;
-      }
-
-      .c0 {
-        width: -webkit-max-content;
-        width: -moz-max-content;
-        width: max-content;
-        background: #ffffff;
-        height: 100%;
-        position: relative;
       }
 
       .c8 > * {

--- a/packages/strapi-design-system/src/SubNav/SubNav.js
+++ b/packages/strapi-design-system/src/SubNav/SubNav.js
@@ -6,6 +6,7 @@ import { Grid } from '../Grid';
 const SubNavWrapper = styled(Grid)`
   width: ${232 / 16}rem;
   background: ${({ theme }) => theme.colors.neutral100};
+  border-right: 1px solid ${({ theme }) => theme.colors.neutral200};
   height: 100%;
   position: relative;
   overflow-y: auto;

--- a/packages/strapi-design-system/src/SubNav/SubNavHeader.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavHeader.js
@@ -111,7 +111,13 @@ export const SubNavHeader = ({ as, label, searchLabel, searchable, onChange, val
       <Row justifyContent="space-between">
         <H2 as={as}>{label}</H2>
         {searchable && (
-          <IconButton ref={searchButtonRef} onClick={toggleSearch} label={searchLabel} icon={<Search />} />
+          <IconButton
+            tooltipPosition="right"
+            ref={searchButtonRef}
+            onClick={toggleSearch}
+            label={searchLabel}
+            icon={<Search />}
+          />
         )}
       </Row>
       <Box paddingTop={4}>

--- a/packages/strapi-design-system/src/SubNav/__tests__/SubNav.spec.js
+++ b/packages/strapi-design-system/src/SubNav/__tests__/SubNav.spec.js
@@ -133,6 +133,7 @@ describe('SubNav', () => {
       .c0 {
         width: 14.5rem;
         background: #f6f6f9;
+        border-right: 1px solid #dcdce4;
         height: 100%;
         position: relative;
         overflow-y: auto;


### PR DESCRIPTION
Signed-off-by: HichamELBSI <elabbassih@gmail.com>

I add some modifications to the `MainNav` component in order to fix the `NavUser` top Divider.

![Screenshot 2021-07-09 at 17 21 53](https://user-images.githubusercontent.com/7756284/125101207-429cd980-e0da-11eb-879e-35c22853293b.png)
![Screenshot 2021-07-09 at 17 22 06](https://user-images.githubusercontent.com/7756284/125101209-43ce0680-e0da-11eb-879a-6fe7e111132e.png)

I also add z-index to the NavCondense button and add the subnav to the CRA example app.

![Screenshot 2021-07-09 at 17 23 54](https://user-images.githubusercontent.com/7756284/125101410-78da5900-e0da-11eb-9c3d-5fb011febfca.png)
![Screenshot 2021-07-09 at 17 24 01](https://user-images.githubusercontent.com/7756284/125101413-7a0b8600-e0da-11eb-8e41-31f10e93430c.png)
