### PR TITLE
Making MainNav aware of react-router-dom

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,6 +1,6 @@
-import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
-import { EditViewPage } from './pages/EditViewPage';
-import CM from './CM';
+import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
+import { EditViewPage } from "./pages/EditViewPage";
+import CM from "./CM";
 
 function App() {
   return (

--- a/example/src/shared/SideNav/index.js
+++ b/example/src/shared/SideNav/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState } from "react";
 import {
   MainNav,
   NavBrand,
@@ -7,11 +7,11 @@ import {
   NavSection,
   NavUser,
   NavCondense,
-} from '@strapi/design-system/MainNav';
-import { Divider } from '@strapi/design-system/Divider';
-import ContentIcon from '@strapi/icons/ContentIcon';
-import menu from './utils/menu';
-import strapiImage from './strapi-img.png';
+} from "@strapi/design-system/MainNav";
+import { Divider } from "@strapi/design-system/Divider";
+import ContentIcon from "@strapi/icons/ContentIcon";
+import menu from "./utils/menu";
+import strapiImage from "./strapi-img.png";
 
 export const SideNav = () => {
   const [condensed, setCondensed] = useState(false);
@@ -25,7 +25,7 @@ export const SideNav = () => {
       />
       <Divider />
       <NavSections>
-        <NavLink href="/content" icon={<ContentIcon />}>
+        <NavLink to="/cm" icon={<ContentIcon />}>
           Content
         </NavLink>
 
@@ -34,7 +34,7 @@ export const SideNav = () => {
             const Icon = link.icon;
 
             return (
-              <NavLink href={link.to} key={link.to} icon={<Icon />}>
+              <NavLink to={link.to} key={link.to} icon={<Icon />}>
                 {link.intlLabel.defaultMessage}
               </NavLink>
             );
@@ -45,7 +45,7 @@ export const SideNav = () => {
             const Icon = link.icon;
 
             return (
-              <NavLink href={link.to} key={link.to} icon={<Icon />}>
+              <NavLink to={link.to} key={link.to} icon={<Icon />}>
                 {link.intlLabel.defaultMessage}
               </NavLink>
             );
@@ -53,11 +53,14 @@ export const SideNav = () => {
         </NavSection>
       </NavSections>
       <Divider />
-      <NavUser src="https://avatars.githubusercontent.com/u/3874873?v=4" href="/somewhere-i-belong">
+      <NavUser
+        src="https://avatars.githubusercontent.com/u/3874873?v=4"
+        to="/somewhere-i-belong"
+      >
         John Duff
       </NavUser>
       <NavCondense onClick={() => setCondensed((s) => !s)}>
-        {condensed ? 'Expanded the navbar' : 'Collapse the navbar'}
+        {condensed ? "Expanded the navbar" : "Collapse the navbar"}
       </NavCondense>
     </MainNav>
   );

--- a/packages/strapi-design-system/package.json
+++ b/packages/strapi-design-system/package.json
@@ -32,6 +32,7 @@
     "prettier": "^2.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-router-dom": "^5.2.0",
     "styled-components": "^5.2.1",
     "webpack-bundle-analyzer": "^4.4.0",
     "webpack-cli": "^4.5.0"
@@ -40,6 +41,7 @@
     "@strapi/icons": "^0.0.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-router-dom": "^5.2.0",
     "styled-components": "^5.2.1"
   },
   "dependencies": {

--- a/packages/strapi-design-system/src/MainNav/MainNav.stories.mdx
+++ b/packages/strapi-design-system/src/MainNav/MainNav.stories.mdx
@@ -9,6 +9,7 @@ import AlertInfoIcon from '@strapi/icons/AlertInfoIcon';
 import PluginsIcon from '@strapi/icons/PluginsIcons';
 import MarketPlaceIcon from '@strapi/icons/MarketplaceIcon';
 import SettingsIcon from '@strapi/icons/Settings';
+import { MemoryRouter } from 'react-router-dom';
 import { MainNav } from './MainNav';
 import { NavSection } from './NavSection';
 import { NavSections } from './NavSections';
@@ -35,46 +36,48 @@ Description...
     {() => {
       const [condensed, setCondensed] = useState(false);
       return (
-        <Box background="neutral100" padding={10} style={{ height: '100vh' }}>
-          <MainNav condensed={condensed}>
-            <NavBrand workplace="Workplace" title="Strapi Dashboard" icon={<img src={strapiImage} alt="" />} />
-            <Divider />
-            <NavSections>
-              <NavLink href="/content" icon={<ContentIcon />} className="active">
-                Content
-              </NavLink>
-              <NavSection label="Plugins">
-                <NavLink href="/builder" icon={<CtbIcon />} active>
-                  Builder
+        <MemoryRouter>
+          <Box background="neutral100" padding={10} style={{ height: '100vh' }}>
+            <MainNav condensed={condensed}>
+              <NavBrand workplace="Workplace" title="Strapi Dashboard" icon={<img src={strapiImage} alt="" />} />
+              <Divider />
+              <NavSections>
+                <NavLink to="/cm" icon={<ContentIcon />} className="active">
+                  Content
                 </NavLink>
-                <NavLink href="/content" icon={<MediaLibIcon />}>
-                  Media library
-                </NavLink>
-                <NavLink href="/content" icon={<AlertInfoIcon />}>
-                  Documentation
-                </NavLink>
-              </NavSection>
-              <NavSection label="General">
-                <NavLink href="/builder" icon={<PluginsIcon />}>
-                  Plugins
-                </NavLink>
-                <NavLink href="/content" icon={<MarketPlaceIcon />}>
-                  Marketplace
-                </NavLink>
-                <NavLink href="/content" icon={<SettingsIcon />}>
-                  Settings
-                </NavLink>
-              </NavSection>
-            </NavSections>
-            <Divider />
-            <NavUser src="https://avatars.githubusercontent.com/u/3874873?v=4" href="/somewhere-i-belong">
-              John Duff
-            </NavUser>
-            <NavCondense onClick={() => setCondensed((s) => !s)}>
-              {condensed ? 'Expanded the navbar' : 'Collapse the navbar'}
-            </NavCondense>
-          </MainNav>
-        </Box>
+                <NavSection label="Plugins">
+                  <NavLink to="/builder" icon={<CtbIcon />}>
+                    Builder
+                  </NavLink>
+                  <NavLink to="/content" icon={<MediaLibIcon />}>
+                    Media library
+                  </NavLink>
+                  <NavLink to="/content" icon={<AlertInfoIcon />}>
+                    Documentation
+                  </NavLink>
+                </NavSection>
+                <NavSection label="General">
+                  <NavLink to="/builder" icon={<PluginsIcon />}>
+                    Plugins
+                  </NavLink>
+                  <NavLink to="/content" icon={<MarketPlaceIcon />}>
+                    Marketplace
+                  </NavLink>
+                  <NavLink to="/content" icon={<SettingsIcon />}>
+                    Settings
+                  </NavLink>
+                </NavSection>
+              </NavSections>
+              <Divider />
+              <NavUser src="https://avatars.githubusercontent.com/u/3874873?v=4" to="/somewhere-i-belong">
+                John Duff
+              </NavUser>
+              <NavCondense onClick={() => setCondensed((s) => !s)}>
+                {condensed ? 'Expanded the navbar' : 'Collapse the navbar'}
+              </NavCondense>
+            </MainNav>
+          </Box>
+        </MemoryRouter>
       );
     }}
   </Story>

--- a/packages/strapi-design-system/src/MainNav/MainNav.stories.mdx
+++ b/packages/strapi-design-system/src/MainNav/MainNav.stories.mdx
@@ -20,10 +20,7 @@ import { Box } from '../Box';
 import { Divider } from '../Divider';
 import strapiImage from './strapi-img.png';
 
-<Meta
-  title="Design System/Organisms/MainNav"
-  component={MainNav}
-/>
+<Meta title="Design System/Organisms/MainNav" component={MainNav} />
 
 # MainNav
 
@@ -43,7 +40,7 @@ Description...
             <NavBrand workplace="Workplace" title="Strapi Dashboard" icon={<img src={strapiImage} alt="" />} />
             <Divider />
             <NavSections>
-              <NavLink href="/content" icon={<ContentIcon />}>
+              <NavLink href="/content" icon={<ContentIcon />} className="active">
                 Content
               </NavLink>
               <NavSection label="Plugins">

--- a/packages/strapi-design-system/src/MainNav/NavLink.js
+++ b/packages/strapi-design-system/src/MainNav/NavLink.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
+import { NavLink as RouterLink } from 'react-router-dom';
 import { Box } from '../Box';
 import { Row } from '../Row';
 import { Text } from '../Text';
@@ -12,7 +13,7 @@ const IconBox = styled(Box)`
 `;
 
 // TODO: make sure to use the Link component associated with the router we want to use
-const MainNavLinkWrapper = styled.a`
+const MainNavLinkWrapper = styled(RouterLink)`
   text-decoration: none;
   display: block;
   border-radius: ${({ theme }) => theme.borderRadius};

--- a/packages/strapi-design-system/src/MainNav/NavLink.js
+++ b/packages/strapi-design-system/src/MainNav/NavLink.js
@@ -16,10 +16,14 @@ const MainNavLinkWrapper = styled.a`
   text-decoration: none;
   display: block;
   border-radius: ${({ theme }) => theme.borderRadius};
-  background: ${({ theme, active }) => (active ? theme.colors.primary100 : theme.colors.neutral0)};
+  background: ${({ theme }) => theme.colors.neutral0};
+
+  ${Text} {
+    color: ${({ theme }) => theme.colors.neutral600};
+  }
 
   svg path {
-    fill: ${({ theme, active }) => (active ? theme.colors.primary600 : theme.colors.neutral500)};
+    fill: ${({ theme }) => theme.colors.neutral500};
   }
 
   &:hover {
@@ -33,20 +37,33 @@ const MainNavLinkWrapper = styled.a`
       fill: ${({ theme }) => theme.colors.neutral600};
     }
   }
+
+  &.active {
+    background: ${({ theme }) => theme.colors.primary100};
+
+    svg path {
+      fill: ${({ theme }) => theme.colors.primary600};
+    }
+
+    ${Text} {
+      color: ${({ theme }) => theme.colors.primary600};
+      font-weight: 500;
+    }
+  }
 `;
 
 const MainNavRow = styled(Row)`
   padding: ${({ theme }) => `${theme.spaces[2]} ${theme.spaces[3]}`};
 `;
 
-export const NavLink = ({ children, icon, active, ...props }) => {
+export const NavLink = ({ children, icon, ...props }) => {
   const condensed = useMainNav();
 
   if (condensed) {
     return (
       <li>
         <Tooltip position="right" label={children}>
-          <MainNavLinkWrapper {...props} active={active} aria-current={active}>
+          <MainNavLinkWrapper {...props}>
             <MainNavRow as="span">
               <IconBox aria-hidden paddingRight={0} as="span">
                 {icon}
@@ -60,27 +77,20 @@ export const NavLink = ({ children, icon, active, ...props }) => {
 
   return (
     <li>
-      <MainNavLinkWrapper {...props} active={active} aria-current={active}>
+      <MainNavLinkWrapper {...props}>
         <MainNavRow as="span">
           <IconBox aria-hidden paddingRight={3} as="span">
             {icon}
           </IconBox>
 
-          <Text textColor={active ? 'primary600' : 'neutral600'} highlighted={active}>
-            {children}
-          </Text>
+          <Text>{children}</Text>
         </MainNavRow>
       </MainNavLinkWrapper>
     </li>
   );
 };
 
-NavLink.defaultProps = {
-  active: false,
-};
-
 NavLink.propTypes = {
-  active: PropTypes.bool,
   children: PropTypes.string.isRequired,
   icon: PropTypes.node.isRequired,
 };

--- a/packages/strapi-design-system/src/MainNav/NavUser.js
+++ b/packages/strapi-design-system/src/MainNav/NavUser.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { NavLink } from 'react-router-dom';
 import { Avatar } from '../Avatar';
 import { Text } from '../Text';
 import { Row } from '../Row';
@@ -19,7 +20,7 @@ export const NavUser = ({ src, children, ...props }) => {
   const condensed = useMainNav();
 
   return (
-    <NavUserBox paddingTop={3} paddingBottom={3} paddingLeft={5} paddingRight={5} as="a" {...props}>
+    <NavUserBox paddingTop={3} paddingBottom={3} paddingLeft={5} paddingRight={5} as={NavLink} {...props}>
       <Row as="span" justifyContent={condensed ? 'center' : undefined}>
         <Avatar src={src} alt="" aria-hidden />
         {condensed ? (

--- a/packages/strapi-design-system/src/MainNav/__tests__/MainNav.spec.js
+++ b/packages/strapi-design-system/src/MainNav/__tests__/MainNav.spec.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
 import { MainNav } from '../MainNav';
 import { NavSection } from '../NavSection';
 import { NavSections } from '../NavSections';
@@ -17,47 +18,49 @@ jest.mock('uuid', () => ({
 describe('MainNav', () => {
   it('snapshots the component in full size', () => {
     const { container } = render(
-      <ThemeProvider theme={lightTheme}>
-        <MainNav condensed={false}>
-          <NavBrand workplace="Workplace" title="Strapi Dashboard" icon={<span>icon</span>} />
-          <Box paddingBottom={3}>
-            <Divider />
-          </Box>
-          <NavSections>
-            <NavLink href="/content" icon={<span>icon</span>}>
-              Content
-            </NavLink>
-            <NavSection label="Plugins">
-              <NavLink href="/builder" icon={<span>icon</span>} active>
-                Builder
+      <BrowserRouter>
+        <ThemeProvider theme={lightTheme}>
+          <MainNav condensed={false}>
+            <NavBrand workplace="Workplace" title="Strapi Dashboard" icon={<span>icon</span>} />
+            <Box paddingBottom={3}>
+              <Divider />
+            </Box>
+            <NavSections>
+              <NavLink to="/content" icon={<span>icon</span>}>
+                Content
               </NavLink>
-              <NavLink href="/content" icon={<span>icon</span>}>
-                Media library
-              </NavLink>
-              <NavLink href="/content" icon={<span>icon</span>}>
-                Documentation
-              </NavLink>
-            </NavSection>
-            <NavSection label="General">
-              <NavLink href="/builder" icon={<span>icon</span>}>
-                Plugins
-              </NavLink>
-              <NavLink href="/content" icon={<span>icon</span>}>
-                Marketplace
-              </NavLink>
-              <NavLink href="/content" icon={<span>icon</span>}>
-                Settings
-              </NavLink>
-            </NavSection>
-          </NavSections>
-          <Box paddingTop={3} paddingBottom={3}>
-            <Divider />
-          </Box>
-          <Box>
-            <button onClick={() => {}}>{`<`}</button>
-          </Box>
-        </MainNav>
-      </ThemeProvider>,
+              <NavSection label="Plugins">
+                <NavLink to="/builder" icon={<span>icon</span>}>
+                  Builder
+                </NavLink>
+                <NavLink to="/content" icon={<span>icon</span>}>
+                  Media library
+                </NavLink>
+                <NavLink to="/content" icon={<span>icon</span>}>
+                  Documentation
+                </NavLink>
+              </NavSection>
+              <NavSection label="General">
+                <NavLink to="/builder" icon={<span>icon</span>}>
+                  Plugins
+                </NavLink>
+                <NavLink to="/content" icon={<span>icon</span>}>
+                  Marketplace
+                </NavLink>
+                <NavLink to="/content" icon={<span>icon</span>}>
+                  Settings
+                </NavLink>
+              </NavSection>
+            </NavSections>
+            <Box paddingTop={3} paddingBottom={3}>
+              <Divider />
+            </Box>
+            <Box>
+              <button onClick={() => {}}>{`<`}</button>
+            </Box>
+          </MainNav>
+        </ThemeProvider>
+      </BrowserRouter>,
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
@@ -99,7 +102,7 @@ describe('MainNav', () => {
         border-radius: 4px;
       }
 
-      .c24 {
+      .c23 {
         padding-top: 12px;
         padding-bottom: 12px;
       }
@@ -129,14 +132,13 @@ describe('MainNav', () => {
         font-weight: 400;
         font-size: 0.875rem;
         line-height: 1.43;
-        color: #666687;
       }
 
-      .c23 {
-        font-weight: 500;
+      .c21 {
+        font-weight: 400;
         font-size: 0.875rem;
         line-height: 1.43;
-        color: #4945ff;
+        color: #666687;
       }
 
       .c7 {
@@ -144,7 +146,7 @@ describe('MainNav', () => {
         line-height: 1.14;
       }
 
-      .c21 {
+      .c22 {
         font-weight: 600;
         font-size: 0.6875rem;
         line-height: 1.45;
@@ -201,6 +203,10 @@ describe('MainNav', () => {
         background: #ffffff;
       }
 
+      .c14 .c5 {
+        color: #666687;
+      }
+
       .c14 svg path {
         fill: #8e8ea9;
       }
@@ -217,28 +223,17 @@ describe('MainNav', () => {
         fill: #666687;
       }
 
-      .c22 {
-        -webkit-text-decoration: none;
-        text-decoration: none;
-        display: block;
-        border-radius: 4px;
+      .c14.active {
         background: #f0f0ff;
       }
 
-      .c22 svg path {
+      .c14.active svg path {
         fill: #4945ff;
       }
 
-      .c22:hover {
-        background: #f6f6f9;
-      }
-
-      .c22:hover .c5 {
-        color: #4a4a6a;
-      }
-
-      .c22:hover svg path {
-        fill: #666687;
+      .c14.active .c5 {
+        color: #4945ff;
+        font-weight: 500;
       }
 
       .c15 {
@@ -304,7 +299,6 @@ describe('MainNav', () => {
           >
             <li>
               <a
-                aria-current="false"
                 class="c14"
                 href="/content"
               >
@@ -337,7 +331,7 @@ describe('MainNav', () => {
                   class="c20"
                 >
                   <span
-                    class="c5 c18 c7 c21"
+                    class="c5 c21 c7 c22"
                   >
                     Plugins
                   </span>
@@ -347,8 +341,7 @@ describe('MainNav', () => {
                 >
                   <li>
                     <a
-                      aria-current="true"
-                      class="c22"
+                      class="c14"
                       href="/builder"
                     >
                       <span
@@ -363,7 +356,7 @@ describe('MainNav', () => {
                           </span>
                         </span>
                         <span
-                          class="c5 c23"
+                          class="c5 c18"
                         >
                           Builder
                         </span>
@@ -372,7 +365,6 @@ describe('MainNav', () => {
                   </li>
                   <li>
                     <a
-                      aria-current="false"
                       class="c14"
                       href="/content"
                     >
@@ -397,7 +389,6 @@ describe('MainNav', () => {
                   </li>
                   <li>
                     <a
-                      aria-current="false"
                       class="c14"
                       href="/content"
                     >
@@ -433,7 +424,7 @@ describe('MainNav', () => {
                   class="c20"
                 >
                   <span
-                    class="c5 c18 c7 c21"
+                    class="c5 c21 c7 c22"
                   >
                     General
                   </span>
@@ -443,7 +434,6 @@ describe('MainNav', () => {
                 >
                   <li>
                     <a
-                      aria-current="false"
                       class="c14"
                       href="/builder"
                     >
@@ -468,7 +458,6 @@ describe('MainNav', () => {
                   </li>
                   <li>
                     <a
-                      aria-current="false"
                       class="c14"
                       href="/content"
                     >
@@ -493,7 +482,6 @@ describe('MainNav', () => {
                   </li>
                   <li>
                     <a
-                      aria-current="false"
                       class="c14"
                       href="/content"
                     >
@@ -522,7 +510,7 @@ describe('MainNav', () => {
           </ul>
         </div>
         <div
-          class="c24"
+          class="c23"
         >
           <hr
             class="c10 c11"
@@ -541,47 +529,49 @@ describe('MainNav', () => {
 
   it('snapshots the component in condensed size', () => {
     const { container } = render(
-      <ThemeProvider theme={lightTheme}>
-        <MainNav condensed={true}>
-          <NavBrand workplace="Workplace" title="Strapi Dashboard" icon={<span>icon</span>} />
-          <Box paddingBottom={3}>
-            <Divider />
-          </Box>
-          <NavSections>
-            <NavLink href="/content" icon={<span>icon</span>}>
-              Content
-            </NavLink>
-            <NavSection label="Plugins">
-              <NavLink href="/builder" icon={<span>icon</span>} active>
-                Builder
+      <BrowserRouter>
+        <ThemeProvider theme={lightTheme}>
+          <MainNav condensed={true}>
+            <NavBrand workplace="Workplace" title="Strapi Dashboard" icon={<span>icon</span>} />
+            <Box paddingBottom={3}>
+              <Divider />
+            </Box>
+            <NavSections>
+              <NavLink to="/content" icon={<span>icon</span>}>
+                Content
               </NavLink>
-              <NavLink href="/content" icon={<span>icon</span>}>
-                Media library
-              </NavLink>
-              <NavLink href="/content" icon={<span>icon</span>}>
-                Documentation
-              </NavLink>
-            </NavSection>
-            <NavSection label="General">
-              <NavLink href="/builder" icon={<span>icon</span>}>
-                Plugins
-              </NavLink>
-              <NavLink href="/content" icon={<span>icon</span>}>
-                Marketplace
-              </NavLink>
-              <NavLink href="/content" icon={<span>icon</span>}>
-                Settings
-              </NavLink>
-            </NavSection>
-          </NavSections>
-          <Box paddingTop={3} paddingBottom={3}>
-            <Divider />
-          </Box>
-          <Box>
-            <button onClick={() => {}}>{`<`}</button>
-          </Box>
-        </MainNav>
-      </ThemeProvider>,
+              <NavSection label="Plugins">
+                <NavLink to="/builder" icon={<span>icon</span>}>
+                  Builder
+                </NavLink>
+                <NavLink to="/content" icon={<span>icon</span>}>
+                  Media library
+                </NavLink>
+                <NavLink to="/content" icon={<span>icon</span>}>
+                  Documentation
+                </NavLink>
+              </NavSection>
+              <NavSection label="General">
+                <NavLink to="/builder" icon={<span>icon</span>}>
+                  Plugins
+                </NavLink>
+                <NavLink to="/content" icon={<span>icon</span>}>
+                  Marketplace
+                </NavLink>
+                <NavLink to="/content" icon={<span>icon</span>}>
+                  Settings
+                </NavLink>
+              </NavSection>
+            </NavSections>
+            <Box paddingTop={3} paddingBottom={3}>
+              <Divider />
+            </Box>
+            <Box>
+              <button onClick={() => {}}>{`<`}</button>
+            </Box>
+          </MainNav>
+        </ThemeProvider>
+      </BrowserRouter>,
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
@@ -617,7 +607,7 @@ describe('MainNav', () => {
         border-radius: 4px;
       }
 
-      .c17 {
+      .c16 {
         padding-top: 12px;
         padding-bottom: 12px;
       }
@@ -693,6 +683,10 @@ describe('MainNav', () => {
         background: #ffffff;
       }
 
+      .c9 .c17 {
+        color: #666687;
+      }
+
       .c9 svg path {
         fill: #8e8ea9;
       }
@@ -701,7 +695,7 @@ describe('MainNav', () => {
         background: #f6f6f9;
       }
 
-      .c9:hover .c18 {
+      .c9:hover .c17 {
         color: #4a4a6a;
       }
 
@@ -709,28 +703,17 @@ describe('MainNav', () => {
         fill: #666687;
       }
 
-      .c16 {
-        -webkit-text-decoration: none;
-        text-decoration: none;
-        display: block;
-        border-radius: 4px;
+      .c9.active {
         background: #f0f0ff;
       }
 
-      .c16 svg path {
+      .c9.active svg path {
         fill: #4945ff;
       }
 
-      .c16:hover {
-        background: #f6f6f9;
-      }
-
-      .c16:hover .c18 {
-        color: #4a4a6a;
-      }
-
-      .c16:hover svg path {
-        fill: #666687;
+      .c9.active .c17 {
+        color: #4945ff;
+        font-weight: 500;
       }
 
       .c11 {
@@ -789,7 +772,6 @@ describe('MainNav', () => {
             <li>
               <span>
                 <a
-                  aria-current="false"
                   aria-labelledby="tooltip-1"
                   class="c9"
                   href="/content"
@@ -836,9 +818,8 @@ describe('MainNav', () => {
                   <li>
                     <span>
                       <a
-                        aria-current="true"
                         aria-labelledby="tooltip-1"
-                        class="c16"
+                        class="c9"
                         href="/builder"
                         tabindex="0"
                       >
@@ -860,7 +841,6 @@ describe('MainNav', () => {
                   <li>
                     <span>
                       <a
-                        aria-current="false"
                         aria-labelledby="tooltip-1"
                         class="c9"
                         href="/content"
@@ -884,7 +864,6 @@ describe('MainNav', () => {
                   <li>
                     <span>
                       <a
-                        aria-current="false"
                         aria-labelledby="tooltip-1"
                         class="c9"
                         href="/content"
@@ -934,7 +913,6 @@ describe('MainNav', () => {
                   <li>
                     <span>
                       <a
-                        aria-current="false"
                         aria-labelledby="tooltip-1"
                         class="c9"
                         href="/builder"
@@ -958,7 +936,6 @@ describe('MainNav', () => {
                   <li>
                     <span>
                       <a
-                        aria-current="false"
                         aria-labelledby="tooltip-1"
                         class="c9"
                         href="/content"
@@ -982,7 +959,6 @@ describe('MainNav', () => {
                   <li>
                     <span>
                       <a
-                        aria-current="false"
                         aria-labelledby="tooltip-1"
                         class="c9"
                         href="/content"
@@ -1009,7 +985,7 @@ describe('MainNav', () => {
           </ul>
         </div>
         <div
-          class="c17"
+          class="c16"
         >
           <hr
             class="c5 c6"

--- a/packages/strapi-design-system/webpack.config.js
+++ b/packages/strapi-design-system/webpack.config.js
@@ -30,7 +30,7 @@ if (process.env.BUNDLE_ANALYZE) {
 
 module.exports = {
   entry,
-  mode: 'development',
+  mode: 'production',
   output: {
     filename: '[name].js',
     path: path.resolve(__dirname, 'dist'),

--- a/packages/strapi-design-system/webpack.config.js
+++ b/packages/strapi-design-system/webpack.config.js
@@ -30,7 +30,7 @@ if (process.env.BUNDLE_ANALYZE) {
 
 module.exports = {
   entry,
-  mode: 'production',
+  mode: 'development',
   output: {
     filename: '[name].js',
     path: path.resolve(__dirname, 'dist'),
@@ -64,6 +64,7 @@ module.exports = {
     {
       react: 'react',
       'react-dom': 'react-dom',
+      'react-router-dom': 'react-router-dom',
       'styled-components': 'styled-components',
     },
     /^@strapi\/icons/,

--- a/packages/strapi-design-system/yarn.lock
+++ b/packages/strapi-design-system/yarn.lock
@@ -1077,7 +1077,7 @@
     core-js-pure "^3.15.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
   integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
@@ -6422,6 +6422,18 @@ highlight.js@^10.1.1, highlight.js@~10.7.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
+history@^4.9.0:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -6431,7 +6443,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -7086,6 +7098,11 @@ is-wsl@^2.1.1, is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -7916,7 +7933,7 @@ lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -8194,6 +8211,14 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
+mini-create-react-context@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
+  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    tiny-warning "^1.0.3"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -8979,6 +9004,13 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -9616,7 +9648,7 @@ react-inspector@^5.1.0:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
-react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -9652,6 +9684,35 @@ react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
+
+react-router-dom@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
+  integrity sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.2.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"
+  integrity sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.4.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-sizeme@^3.0.1:
   version "3.0.1"
@@ -9993,6 +10054,11 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -10995,6 +11061,16 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+tiny-invariant@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
+
+tiny-warning@^1.0.0, tiny-warning@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
@@ -11490,6 +11566,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
(not managing linting diff in this PR)

Allows to make the MainNav component aware of react-router-dom and to highlight the selected link based on what react-router-dom provides (e.g: an `active` className instead of a react prop)