### PR TITLE
Add Modal Layout

### DIFF
--- a/packages/strapi-design-system/src/ModalLayout/ModalBody.js
+++ b/packages/strapi-design-system/src/ModalLayout/ModalBody.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Box } from '../Box';
+
+export const ModalBody = (props) => {
+  return <Box paddingTop={6} paddingBottom={6} paddingLeft={8} paddingRight={8} {...props} />;
+};

--- a/packages/strapi-design-system/src/ModalLayout/ModalContext.js
+++ b/packages/strapi-design-system/src/ModalLayout/ModalContext.js
@@ -1,0 +1,4 @@
+import { createContext, useContext } from 'react';
+
+export const ModalContext = createContext();
+export const useModal = () => useContext(ModalContext);

--- a/packages/strapi-design-system/src/ModalLayout/ModalFooter.js
+++ b/packages/strapi-design-system/src/ModalLayout/ModalFooter.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import { Box } from '../Box';
+import { Row } from '../Row';
+
+const ModalFooterWrapper = styled(Box)`
+  border-top: 1px solid ${({ theme }) => theme.colors.neutral150};
+`;
+
+const ActionWrapper = styled(Row)`
+  & > * + * {
+    margin-left: ${({ theme }) => theme.spaces[2]};
+  }
+`;
+
+export const ModalFooter = ({ startActions, endActions }) => {
+  return (
+    <ModalFooterWrapper paddingTop={4} paddingBottom={4} paddingLeft={5} paddingRight={5} background="neutral100">
+      <Row justifyContent="space-between">
+        <ActionWrapper>{startActions}</ActionWrapper>
+        <ActionWrapper>{endActions}</ActionWrapper>
+      </Row>
+    </ModalFooterWrapper>
+  );
+};
+
+ModalFooter.defaultProps = {
+  endActions: undefined,
+  startActions: undefined,
+};
+
+ModalFooter.propTypes = {
+  endActions: PropTypes.node,
+  startActions: PropTypes.node,
+};

--- a/packages/strapi-design-system/src/ModalLayout/ModalHeader.js
+++ b/packages/strapi-design-system/src/ModalLayout/ModalHeader.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import CloseAlertIcon from '@strapi/icons/CloseAlertIcon';
+import { Row } from '../Row';
+import { Box } from '../Box';
+import { IconButton } from '../IconButton';
+import { useModal } from './ModalContext';
+
+const ModalHeaderWrapper = styled(Box)`
+  border-bottom: 1px solid ${({ theme }) => theme.colors.neutral150};
+`;
+
+export const ModalHeader = ({ children, closeLabel }) => {
+  const onClose = useModal();
+
+  return (
+    <ModalHeaderWrapper paddingTop={4} paddingBottom={4} paddingLeft={5} paddingRight={5} background="neutral100">
+      <Row justifyContent="space-between">
+        {children}
+        <IconButton onClick={onClose} label={closeLabel} icon={<CloseAlertIcon />} />
+      </Row>
+    </ModalHeaderWrapper>
+  );
+};
+
+ModalHeader.defaultProps = {
+  closeLabel: 'Close the modal',
+};
+
+ModalHeader.propTypes = {
+  children: PropTypes.node.isRequired,
+  closeLabel: PropTypes.string,
+};

--- a/packages/strapi-design-system/src/ModalLayout/ModalLayout.js
+++ b/packages/strapi-design-system/src/ModalLayout/ModalLayout.js
@@ -16,7 +16,7 @@ const ModalWrapper = styled.div`
 
 const ModalContent = styled(Box)`
   position: relative;
-  max-width: ${800 / 16}rem;
+  max-width: ${830 / 16}rem;
   margin: 0 auto;
   overflow: hidden;
   margin-top: 10%;

--- a/packages/strapi-design-system/src/ModalLayout/ModalLayout.js
+++ b/packages/strapi-design-system/src/ModalLayout/ModalLayout.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import { Box } from '../Box';
+import { FocusTrap } from '../FocusTrap';
+import { Portal } from '../Portal';
+import { ModalContext } from './ModalContext';
+
+const ModalWrapper = styled.div`
+  position: absolute;
+  inset: 0;
+  background: ${({ theme }) => theme.colors.neutral200};
+  opacity: 0.8;
+  padding: 0 ${({ theme }) => theme.spaces[8]};
+`;
+
+const ModalContent = styled(Box)`
+  position: relative;
+  max-width: ${800 / 16}rem;
+  margin: 0 auto;
+  overflow: hidden;
+  margin-top: 10%;
+`;
+
+export const ModalLayout = ({ onClose, labelledBy, ...props }) => {
+  return (
+    <Portal>
+      <ModalContext.Provider value={onClose}>
+        <ModalWrapper />
+        <FocusTrap onEscape={onClose}>
+          <ModalContent
+            aria-labelledBy={labelledBy}
+            background="neutral0"
+            hasRadius
+            shadow="popupShadow"
+            role="dialog"
+            aria-modal={true}
+            {...props}
+          />
+        </FocusTrap>
+      </ModalContext.Provider>
+    </Portal>
+  );
+};
+
+ModalLayout.propTypes = {
+  labelledBy: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/packages/strapi-design-system/src/ModalLayout/ModalLayout.stories.mdx
+++ b/packages/strapi-design-system/src/ModalLayout/ModalLayout.stories.mdx
@@ -1,0 +1,42 @@
+<!--- ModalLayout.stories.mdx --->
+
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { ModalLayout } from './ModalLayout';
+import { ModalHeader } from './ModalHeader';
+import { ModalFooter } from './ModalFooter';
+import { ModalBody } from './ModalBody';
+import { TextButton } from '../Text';
+import { Row } from '../Row';
+import { Button } from '../Button';
+
+<Meta title="Design System/Layouts/ModalLayout" component={ModalLayout} />
+
+# ModalLayout
+
+This is the doc of the `ModalLayout` component
+
+## ModalLayout
+
+Description...
+
+<Canvas>
+  <Story name="base">
+    <ModalLayout onClose={() => undefined} labelledBy="title">
+      <ModalHeader>
+        <TextButton textColor="neutral800" as="h2" id="title">
+          Title
+        </TextButton>
+      </ModalHeader>
+      <ModalBody>Hello world</ModalBody>
+      <ModalFooter
+        startActions={<Button variant="tertiary">Cancel</Button>}
+        endActions={
+          <>
+            <Button variant="secondary">Add new stuff</Button>
+            <Button>Finish</Button>
+          </>
+        }
+      />
+    </ModalLayout>
+  </Story>
+</Canvas>

--- a/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.e2e.js
+++ b/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.e2e.js
@@ -1,0 +1,18 @@
+import { injectAxe, getViolations } from 'axe-playwright';
+
+describe('ModalLayout', () => {
+  beforeEach(async () => {
+    // This is the URL of the Storybook Iframe
+    await page.goto('http://localhost:6006/iframe.html?id=design-system-layouts-modallayout--base&viewMode=story');
+    await injectAxe(page);
+  });
+
+  it('triggers axe on the document', async () => {
+    const violations = await getViolations(page);
+
+    // Axe throws an error about landmark for the role dialog
+    const realViolations = violations.filter((violation) => violation.id !== 'region');
+
+    expect(realViolations.length).toBe(0);
+  });
+});

--- a/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.js
+++ b/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.js
@@ -1,0 +1,293 @@
+import * as React from 'react';
+import { render, waitFor, screen } from '@testing-library/react';
+import { ModalLayout } from '../ModalLayout';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+import { ModalBody } from '../ModalBody';
+import { ModalFooter } from '../ModalFooter';
+import { ModalHeader } from '../ModalHeader';
+
+jest.mock('uuid', () => ({
+  v4: () => 1,
+}));
+
+describe('ModalLayout', () => {
+  it('snapshots the component', async () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <ModalLayout onClose={() => undefined}>
+          <ModalHeader>
+            <span>Title</span>
+          </ModalHeader>
+          <ModalBody>Hello world</ModalBody>
+          <ModalFooter
+            startActions={<button>Cancel</button>}
+            endActions={
+              <>
+                <button>Add new stuff</button>
+                <button>Finish</button>
+              </>
+            }
+          />
+        </ModalLayout>
+      </ThemeProvider>,
+      { container: document.body },
+    );
+
+    await waitFor(() => screen.getByRole('dialog'));
+
+    expect(container).toMatchInlineSnapshot(`
+      .c1 {
+        background: #ffffff;
+        border-radius: 4px;
+        box-shadow: 0px 2px 15px rgba(33,33,52,0.1);
+      }
+
+      .c3 {
+        background: #f6f6f9;
+        padding-top: 16px;
+        padding-right: 20px;
+        padding-bottom: 16px;
+        padding-left: 20px;
+      }
+
+      .c8 {
+        padding-top: 24px;
+        padding-right: 40px;
+        padding-bottom: 24px;
+        padding-left: 40px;
+      }
+
+      .c12 {
+        background: #212134;
+        padding: 8px;
+        border-radius: 4px;
+      }
+
+      .c0 {
+        position: absolute;
+        inset: 0;
+        background: #dcdce4;
+        opacity: 0.8;
+        padding: 0 40px;
+      }
+
+      .c2 {
+        position: relative;
+        max-width: 50rem;
+        margin: 0 auto;
+        overflow: hidden;
+        margin-top: 10%;
+      }
+
+      .c5 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-box-pack: justify;
+        -webkit-justify-content: space-between;
+        -ms-flex-pack: justify;
+        justify-content: space-between;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+      }
+
+      .c10 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+      }
+
+      .c9 {
+        border-top: 1px solid #eaeaef;
+      }
+
+      .c11 > * + * {
+        margin-left: 8px;
+      }
+
+      .c15 {
+        font-weight: 500;
+        font-size: 0.75rem;
+        line-height: 1.33;
+        color: #ffffff;
+      }
+
+      .c14 {
+        border: 0;
+        -webkit-clip: rect(0 0 0 0);
+        clip: rect(0 0 0 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+      }
+
+      .c13 {
+        position: absolute;
+        display: revert;
+      }
+
+      .c6 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        cursor: pointer;
+        padding: 8px;
+        border-radius: 4px;
+        background: #ffffff;
+        border: 1px solid #dcdce4;
+      }
+
+      .c6 svg {
+        height: 12px;
+        width: 12px;
+      }
+
+      .c6 svg > g,
+      .c6 svg path {
+        fill: #ffffff;
+      }
+
+      .c6[aria-disabled='true'] {
+        pointer-events: none;
+      }
+
+      .c7 svg > g,
+      .c7 svg path {
+        fill: #8e8ea9;
+      }
+
+      .c7:hover svg > g,
+      .c7:hover svg path {
+        fill: #666687;
+      }
+
+      .c7:active svg > g,
+      .c7:active svg path {
+        fill: #a5a5ba;
+      }
+
+      .c4 {
+        border-bottom: 1px solid #eaeaef;
+      }
+
+      <body>
+        <div
+          data-react-portal="true"
+        >
+          <div
+            class="c0"
+          />
+          <div>
+            <div
+              aria-modal="true"
+              class="c1 c2"
+              role="dialog"
+            >
+              <div
+                class="c3 c4"
+              >
+                <div
+                  class="c5"
+                >
+                  <span>
+                    Title
+                  </span>
+                  <span>
+                    <button
+                      aria-disabled="false"
+                      aria-labelledby="tooltip-1"
+                      class="c6 c7"
+                      tabindex="0"
+                    >
+                      <svg
+                        fill="none"
+                        height="1em"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M24 2.417L21.583 0 12 9.583 2.417 0 0 2.417 9.583 12 0 21.583 2.417 24 12 14.417 21.583 24 24 21.583 14.417 12 24 2.417z"
+                          fill="#212134"
+                        />
+                      </svg>
+                    </button>
+                  </span>
+                </div>
+              </div>
+              <div
+                class="c8"
+              >
+                Hello world
+              </div>
+              <div
+                class="c3 c9"
+              >
+                <div
+                  class="c5"
+                >
+                  <div
+                    class="c10 c11"
+                  >
+                    <button>
+                      Cancel
+                    </button>
+                  </div>
+                  <div
+                    class="c10 c11"
+                  >
+                    <button>
+                      Add new stuff
+                    </button>
+                    <button>
+                      Finish
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          data-react-portal="true"
+        >
+          <div
+            class="c12 c13"
+            id="tooltip-1"
+            role="tooltip"
+            style="left: 0px; top: -8px;"
+          >
+            <div
+              class="c14"
+              id="description-1"
+            />
+            <p
+              class="c15"
+            >
+              Close the modal
+            </p>
+          </div>
+        </div>
+      </body>
+    `);
+  });
+});

--- a/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.js
+++ b/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.js
@@ -74,7 +74,7 @@ describe('ModalLayout', () => {
 
       .c2 {
         position: relative;
-        max-width: 50rem;
+        max-width: 51.875rem;
         margin: 0 auto;
         overflow: hidden;
         margin-top: 10%;

--- a/packages/strapi-design-system/src/ModalLayout/index.js
+++ b/packages/strapi-design-system/src/ModalLayout/index.js
@@ -1,0 +1,4 @@
+export * from './ModalLayout';
+export * from './ModalHeader';
+export * from './ModalFooter';
+export * from './ModalBody';

--- a/packages/strapi-design-system/src/index.js
+++ b/packages/strapi-design-system/src/index.js
@@ -24,6 +24,7 @@ export * from './Link';
 export * from './Loader';
 export * from './Main';
 export * from './MainNav';
+export * from './ModalLayout';
 export * from './OneBlockLayout';
 export * from './Pagination';
 export * from './Popover';


### PR DESCRIPTION
# ModalLayout

## Description

Add a ModalLayout, ModalHeader, ModalBody, ModalFooter to compose dialogs

## Demo

Example on : https://design-system-git-modal-layout-strapijs.vercel.app/?path=/story/design-system-layouts-modallayout--base

## API


```jsx
<ModalLayout onClose={() => undefined} labelledBy="title">
  <ModalHeader>
    <TextButton textColor="neutral800" as="h2" id="title">
      Title
    </TextButton>
  </ModalHeader>
  <ModalBody>Hello world</ModalBody>
  <ModalFooter
    startActions={<Button variant="tertiary">Cancel</Button>}
    endActions={
      <>
        <Button variant="secondary">Add new stuff</Button>
        <Button>Finish</Button>
      </>
    }
  />
</ModalLayout>
```

## Voiceover

![Navigating a dialog using the keyboard and VoiceOver](https://user-images.githubusercontent.com/3874873/126599640-f3d2e593-e8a8-42f8-b1a7-0c8f4441b007.gif)
