### PR TITLE
Add zoom to the Avatar component

### DIFF
--- a/packages/strapi-design-system/src/Avatar/Avatar.js
+++ b/packages/strapi-design-system/src/Avatar/Avatar.js
@@ -1,21 +1,54 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
-const avatarSize = '26px';
+const avatarSize = 26;
+const previewSize = 64;
 
 const AvatarImg = styled.img`
   border-radius: 50%;
   display: block;
-  height: ${avatarSize};
-  width: ${avatarSize};
 `;
 
-export const Avatar = ({ src, alt }) => {
-  return <AvatarImg src={src} alt={alt} width={avatarSize} height={avatarSize} />;
+const PreviewContainer = styled.img`
+  border-radius: 50%;
+  position: absolute;
+  transform: translate(-${(previewSize - avatarSize) / 2}px, -100%);
+  margin-top: -${({ theme }) => theme.spaces[1]};
+`;
+
+export const Avatar = ({ src, alt, preview }) => {
+  const [previewVisible, setPreviewVisible] = useState(false);
+
+  return (
+    <span>
+      {preview && previewVisible && (
+        <PreviewContainer
+          aria-hidden
+          alt=""
+          width={`${previewSize}px`}
+          height={`${previewSize}px`}
+          src={preview === true ? src : preview}
+        />
+      )}
+      <AvatarImg
+        src={src}
+        alt={alt}
+        width={`${avatarSize}px`}
+        height={`${avatarSize}px`}
+        onMouseEnter={() => setPreviewVisible(true)}
+        onMouseLeave={() => setPreviewVisible(false)}
+      />
+    </span>
+  );
+};
+
+Avatar.defaultProps = {
+  preview: undefined,
 };
 
 Avatar.propTypes = {
   alt: PropTypes.string.isRequired,
+  preview: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   src: PropTypes.string.isRequired,
 };

--- a/packages/strapi-design-system/src/Avatar/Avatar.js
+++ b/packages/strapi-design-system/src/Avatar/Avatar.js
@@ -38,7 +38,7 @@ export const Avatar = ({ src, alt, preview }) => {
   const [previewVisible, setPreviewVisible] = useState(false);
 
   return (
-    <div>
+    <span>
       {preview && previewVisible ? (
         <PreviewContainer
           aria-hidden
@@ -53,7 +53,7 @@ export const Avatar = ({ src, alt, preview }) => {
         {preview && previewVisible ? <Overlay /> : null}
         <AvatarImg src={src} alt={alt} width={`${avatarSize}px`} height={`${avatarSize}px`} />
       </AvatarImgWrapper>
-    </div>
+    </span>
   );
 };
 

--- a/packages/strapi-design-system/src/Avatar/Avatar.js
+++ b/packages/strapi-design-system/src/Avatar/Avatar.js
@@ -8,6 +8,11 @@ const previewSize = 64;
 const AvatarImg = styled.img`
   border-radius: 50%;
   display: block;
+  position: relative;
+`;
+
+const AvatarImgWrapper = styled.div`
+  position: relative;
 `;
 
 const PreviewContainer = styled.img`
@@ -17,12 +22,22 @@ const PreviewContainer = styled.img`
   margin-top: -${({ theme }) => theme.spaces[1]};
 `;
 
+const Overlay = styled.div`
+  z-index: 1;
+  border-radius: 50%;
+  position: absolute;
+  width: ${avatarSize}px;
+  height: ${avatarSize}px;
+  background: ${({ theme }) => theme.colors.neutral0};
+  opacity: 0.4;
+`;
+
 export const Avatar = ({ src, alt, preview }) => {
   const [previewVisible, setPreviewVisible] = useState(false);
 
   return (
-    <span>
-      {preview && previewVisible && (
+    <div>
+      {preview && previewVisible ? (
         <PreviewContainer
           aria-hidden
           alt=""
@@ -30,16 +45,13 @@ export const Avatar = ({ src, alt, preview }) => {
           height={`${previewSize}px`}
           src={preview === true ? src : preview}
         />
-      )}
-      <AvatarImg
-        src={src}
-        alt={alt}
-        width={`${avatarSize}px`}
-        height={`${avatarSize}px`}
-        onMouseEnter={() => setPreviewVisible(true)}
-        onMouseLeave={() => setPreviewVisible(false)}
-      />
-    </span>
+      ) : null}
+
+      <AvatarImgWrapper onMouseEnter={() => setPreviewVisible(true)} onMouseLeave={() => setPreviewVisible(false)}>
+        {preview && previewVisible ? <Overlay /> : null}
+        <AvatarImg src={src} alt={alt} width={`${avatarSize}px`} height={`${avatarSize}px`} />
+      </AvatarImgWrapper>
+    </div>
   );
 };
 

--- a/packages/strapi-design-system/src/Avatar/Avatar.js
+++ b/packages/strapi-design-system/src/Avatar/Avatar.js
@@ -13,6 +13,8 @@ const AvatarImg = styled.img`
 
 const AvatarImgWrapper = styled.div`
   position: relative;
+  width: ${avatarSize}px;
+  height: ${avatarSize}px;
 `;
 
 const PreviewContainer = styled.img`

--- a/packages/strapi-design-system/src/Avatar/Avatar.stories.mdx
+++ b/packages/strapi-design-system/src/Avatar/Avatar.stories.mdx
@@ -2,6 +2,7 @@
 
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import { Avatar } from './Avatar';
+import { Box } from '../Box';
 
 <Meta title="Design System/Atoms/Avatar" component={Avatar} />
 
@@ -15,6 +16,8 @@ Description...
 
 <Canvas>
   <Story name="base">
-    <Avatar src="https://avatars.githubusercontent.com/u/3874873?v=4" alt="marvin frachet" />
+    <Box padding={11}>
+      <Avatar src="https://avatars.githubusercontent.com/u/3874873?v=4" alt="marvin frachet" preview />
+    </Box>
   </Story>
 </Canvas>

--- a/packages/strapi-design-system/src/Avatar/__tests__/Avatar.spec.js
+++ b/packages/strapi-design-system/src/Avatar/__tests__/Avatar.spec.js
@@ -25,7 +25,7 @@ describe('Avatar', () => {
         height: 26px;
       }
 
-      <div>
+      <span>
         <div
           class="c0"
         >
@@ -37,7 +37,7 @@ describe('Avatar', () => {
             width="26px"
           />
         </div>
-      </div>
+      </span>
     `);
   });
 
@@ -82,7 +82,7 @@ describe('Avatar', () => {
         opacity: 0.4;
       }
 
-      <div>
+      <span>
         <img
           alt=""
           aria-hidden="true"
@@ -105,7 +105,7 @@ describe('Avatar', () => {
             width="26px"
           />
         </div>
-      </div>
+      </span>
     `);
   });
 
@@ -154,7 +154,7 @@ describe('Avatar', () => {
         opacity: 0.4;
       }
 
-      <div>
+      <span>
         <img
           alt=""
           aria-hidden="true"
@@ -177,7 +177,7 @@ describe('Avatar', () => {
             width="26px"
           />
         </div>
-      </div>
+      </span>
     `);
   });
 });

--- a/packages/strapi-design-system/src/Avatar/__tests__/Avatar.spec.js
+++ b/packages/strapi-design-system/src/Avatar/__tests__/Avatar.spec.js
@@ -21,6 +21,8 @@ describe('Avatar', () => {
 
       .c0 {
         position: relative;
+        width: 26px;
+        height: 26px;
       }
 
       <div>
@@ -57,6 +59,8 @@ describe('Avatar', () => {
 
       .c1 {
         position: relative;
+        width: 26px;
+        height: 26px;
       }
 
       .c0 {
@@ -127,6 +131,8 @@ describe('Avatar', () => {
 
       .c1 {
         position: relative;
+        width: 26px;
+        height: 26px;
       }
 
       .c0 {

--- a/packages/strapi-design-system/src/Avatar/__tests__/Avatar.spec.js
+++ b/packages/strapi-design-system/src/Avatar/__tests__/Avatar.spec.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { Avatar } from '../Avatar';
 import { ThemeProvider } from '../../ThemeProvider';
 import { lightTheme } from '../../themes';
@@ -16,17 +16,109 @@ describe('Avatar', () => {
       .c0 {
         border-radius: 50%;
         display: block;
-        height: 26px;
-        width: 26px;
       }
 
-      <img
-        alt="marvin frachet"
-        class="c0"
-        height="26px"
-        src="https://avatars.githubusercontent.com/u/3874873?v=4"
-        width="26px"
-      />
+      <span>
+        <img
+          alt="marvin frachet"
+          class="c0"
+          height="26px"
+          src="https://avatars.githubusercontent.com/u/3874873?v=4"
+          width="26px"
+        />
+      </span>
+    `);
+  });
+
+  it('snapshots the component with preview (boolean)', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Avatar src="https://avatars.githubusercontent.com/u/3874873?v=4" alt="marvin frachet" preview />
+      </ThemeProvider>,
+    );
+
+    fireEvent.mouseEnter(container.querySelector('img'));
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c1 {
+        border-radius: 50%;
+        display: block;
+      }
+
+      .c0 {
+        border-radius: 50%;
+        position: absolute;
+        -webkit-transform: translate(-19px,-100%);
+        -ms-transform: translate(-19px,-100%);
+        transform: translate(-19px,-100%);
+        margin-top: -4px;
+      }
+
+      <span>
+        <img
+          alt=""
+          aria-hidden="true"
+          class="c0"
+          height="64px"
+          src="https://avatars.githubusercontent.com/u/3874873?v=4"
+          width="64px"
+        />
+        <img
+          alt="marvin frachet"
+          class="c1"
+          height="26px"
+          src="https://avatars.githubusercontent.com/u/3874873?v=4"
+          width="26px"
+        />
+      </span>
+    `);
+  });
+
+  it('snapshots the component with preview (string)', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Avatar
+          src="https://avatars.githubusercontent.com/u/3874873?v=4"
+          alt="marvin frachet"
+          preview="https://some-unknown-photo/x.png"
+        />
+      </ThemeProvider>,
+    );
+
+    fireEvent.mouseEnter(container.querySelector('img'));
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c1 {
+        border-radius: 50%;
+        display: block;
+      }
+
+      .c0 {
+        border-radius: 50%;
+        position: absolute;
+        -webkit-transform: translate(-19px,-100%);
+        -ms-transform: translate(-19px,-100%);
+        transform: translate(-19px,-100%);
+        margin-top: -4px;
+      }
+
+      <span>
+        <img
+          alt=""
+          aria-hidden="true"
+          class="c0"
+          height="64px"
+          src="https://some-unknown-photo/x.png"
+          width="64px"
+        />
+        <img
+          alt="marvin frachet"
+          class="c1"
+          height="26px"
+          src="https://avatars.githubusercontent.com/u/3874873?v=4"
+          width="26px"
+        />
+      </span>
     `);
   });
 });

--- a/packages/strapi-design-system/src/Avatar/__tests__/Avatar.spec.js
+++ b/packages/strapi-design-system/src/Avatar/__tests__/Avatar.spec.js
@@ -13,20 +13,29 @@ describe('Avatar', () => {
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
-      .c0 {
+      .c1 {
         border-radius: 50%;
         display: block;
+        position: relative;
       }
 
-      <span>
-        <img
-          alt="marvin frachet"
+      .c0 {
+        position: relative;
+      }
+
+      <div>
+        <div
           class="c0"
-          height="26px"
-          src="https://avatars.githubusercontent.com/u/3874873?v=4"
-          width="26px"
-        />
-      </span>
+        >
+          <img
+            alt="marvin frachet"
+            class="c1"
+            height="26px"
+            src="https://avatars.githubusercontent.com/u/3874873?v=4"
+            width="26px"
+          />
+        </div>
+      </div>
     `);
   });
 
@@ -40,9 +49,14 @@ describe('Avatar', () => {
     fireEvent.mouseEnter(container.querySelector('img'));
 
     expect(container.firstChild).toMatchInlineSnapshot(`
-      .c1 {
+      .c3 {
         border-radius: 50%;
         display: block;
+        position: relative;
+      }
+
+      .c1 {
+        position: relative;
       }
 
       .c0 {
@@ -54,7 +68,17 @@ describe('Avatar', () => {
         margin-top: -4px;
       }
 
-      <span>
+      .c2 {
+        z-index: 1;
+        border-radius: 50%;
+        position: absolute;
+        width: 26px;
+        height: 26px;
+        background: #ffffff;
+        opacity: 0.4;
+      }
+
+      <div>
         <img
           alt=""
           aria-hidden="true"
@@ -63,14 +87,21 @@ describe('Avatar', () => {
           src="https://avatars.githubusercontent.com/u/3874873?v=4"
           width="64px"
         />
-        <img
-          alt="marvin frachet"
+        <div
           class="c1"
-          height="26px"
-          src="https://avatars.githubusercontent.com/u/3874873?v=4"
-          width="26px"
-        />
-      </span>
+        >
+          <div
+            class="c2"
+          />
+          <img
+            alt="marvin frachet"
+            class="c3"
+            height="26px"
+            src="https://avatars.githubusercontent.com/u/3874873?v=4"
+            width="26px"
+          />
+        </div>
+      </div>
     `);
   });
 
@@ -88,9 +119,14 @@ describe('Avatar', () => {
     fireEvent.mouseEnter(container.querySelector('img'));
 
     expect(container.firstChild).toMatchInlineSnapshot(`
-      .c1 {
+      .c3 {
         border-radius: 50%;
         display: block;
+        position: relative;
+      }
+
+      .c1 {
+        position: relative;
       }
 
       .c0 {
@@ -102,7 +138,17 @@ describe('Avatar', () => {
         margin-top: -4px;
       }
 
-      <span>
+      .c2 {
+        z-index: 1;
+        border-radius: 50%;
+        position: absolute;
+        width: 26px;
+        height: 26px;
+        background: #ffffff;
+        opacity: 0.4;
+      }
+
+      <div>
         <img
           alt=""
           aria-hidden="true"
@@ -111,14 +157,21 @@ describe('Avatar', () => {
           src="https://some-unknown-photo/x.png"
           width="64px"
         />
-        <img
-          alt="marvin frachet"
+        <div
           class="c1"
-          height="26px"
-          src="https://avatars.githubusercontent.com/u/3874873?v=4"
-          width="26px"
-        />
-      </span>
+        >
+          <div
+            class="c2"
+          />
+          <img
+            alt="marvin frachet"
+            class="c3"
+            height="26px"
+            src="https://avatars.githubusercontent.com/u/3874873?v=4"
+            width="26px"
+          />
+        </div>
+      </div>
     `);
   });
 });

--- a/packages/strapi-design-system/src/Table/__tests__/Table.spec.js
+++ b/packages/strapi-design-system/src/Table/__tests__/Table.spec.js
@@ -111,20 +111,20 @@ describe('Table', () => {
         padding-left: 12px;
       }
 
-      .c19 {
+      .c20 {
         background: #eaeaef;
       }
 
-      .c21 {
+      .c22 {
         background: #f0f0ff;
         padding: 20px;
       }
 
-      .c24 {
+      .c25 {
         background: #d9d8ff;
       }
 
-      .c26 {
+      .c27 {
         padding-left: 12px;
       }
 
@@ -276,7 +276,7 @@ describe('Table', () => {
         vertical-align: sub;
       }
 
-      .c20 {
+      .c21 {
         height: 1px;
         margin: 0;
         border: none;
@@ -295,7 +295,7 @@ describe('Table', () => {
         color: #666687;
       }
 
-      .c27 {
+      .c28 {
         font-weight: 500;
         font-size: 0.75rem;
         line-height: 1.33;
@@ -314,7 +314,7 @@ describe('Table', () => {
         text-transform: uppercase;
       }
 
-      .c23 {
+      .c24 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -328,7 +328,7 @@ describe('Table', () => {
         align-items: center;
       }
 
-      .c25 {
+      .c26 {
         height: 1.5rem;
         width: 1.5rem;
         border-radius: 50%;
@@ -346,28 +346,33 @@ describe('Table', () => {
         align-items: center;
       }
 
-      .c25 svg {
+      .c26 svg {
         height: 0.625rem;
         width: 0.625rem;
       }
 
-      .c25 svg path {
+      .c26 svg path {
         fill: #4945ff;
       }
 
-      .c22 {
+      .c23 {
         border-radius: 0 0 4px 4px;
         display: block;
         width: 100%;
         border: none;
       }
 
-      .c16 {
+      .c17 {
         border-radius: 50%;
         display: block;
+        position: relative;
       }
 
-      .c17 {
+      .c16 {
+        position: relative;
+      }
+
+      .c18 {
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -379,36 +384,36 @@ describe('Table', () => {
         border: 1px solid #dcdce4;
       }
 
-      .c17 svg {
+      .c18 svg {
         height: 12px;
         width: 12px;
       }
 
-      .c17 svg > g,
-      .c17 svg path {
+      .c18 svg > g,
+      .c18 svg path {
         fill: #ffffff;
       }
 
-      .c17[aria-disabled='true'] {
+      .c18[aria-disabled='true'] {
         pointer-events: none;
       }
 
-      .c18 {
+      .c19 {
         border: none;
       }
 
-      .c18 svg > g,
-      .c18 svg path {
+      .c19 svg > g,
+      .c19 svg path {
         fill: #8e8ea9;
       }
 
-      .c18:hover svg > g,
-      .c18:hover svg path {
+      .c19:hover svg > g,
+      .c19:hover svg path {
         fill: #666687;
       }
 
-      .c18:active svg > g,
-      .c18:active svg path {
+      .c19:active svg > g,
+      .c19:active svg path {
         fill: #a5a5ba;
       }
 
@@ -546,15 +551,19 @@ describe('Table', () => {
                     class="c8"
                     tabindex="-1"
                   >
-                    <span>
-                      <img
-                        alt="Leon Lafrite"
+                    <div>
+                      <div
                         class="c16"
-                        height="26px"
-                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
-                        width="26px"
-                      />
-                    </span>
+                      >
+                        <img
+                          alt="Leon Lafrite"
+                          class="c17"
+                          height="26px"
+                          src="https://avatars.githubusercontent.com/u/3874873?v=4"
+                          width="26px"
+                        />
+                      </div>
+                    </div>
                   </td>
                   <td
                     aria-colindex="4"
@@ -597,7 +606,7 @@ describe('Table', () => {
                       <button
                         aria-disabled="false"
                         aria-labelledby="tooltip-123"
-                        class="c17 c18"
+                        class="c18 c19"
                         tabindex="-1"
                       >
                         <svg
@@ -649,15 +658,19 @@ describe('Table', () => {
                     class="c8"
                     tabindex="-1"
                   >
-                    <span>
-                      <img
-                        alt="Leon Lafrite"
+                    <div>
+                      <div
                         class="c16"
-                        height="26px"
-                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
-                        width="26px"
-                      />
-                    </span>
+                      >
+                        <img
+                          alt="Leon Lafrite"
+                          class="c17"
+                          height="26px"
+                          src="https://avatars.githubusercontent.com/u/3874873?v=4"
+                          width="26px"
+                        />
+                      </div>
+                    </div>
                   </td>
                   <td
                     aria-colindex="4"
@@ -700,7 +713,7 @@ describe('Table', () => {
                       <button
                         aria-disabled="false"
                         aria-labelledby="tooltip-123"
-                        class="c17 c18"
+                        class="c18 c19"
                         tabindex="-1"
                       >
                         <svg
@@ -727,27 +740,27 @@ describe('Table', () => {
         </div>
         <div>
           <hr
-            class="c19 c20"
+            class="c20 c21"
           />
           <button
-            class="c21 c22"
+            class="c22 c23"
           >
             <div
-              class="c23"
+              class="c24"
             >
               <div
                 aria-hidden="true"
-                class="c24 c25"
+                class="c25 c26"
               >
                 <span>
                   icon
                 </span>
               </div>
               <div
-                class="c26"
+                class="c27"
               >
                 <span
-                  class="c27"
+                  class="c28"
                 >
                   Add another field to this collection type
                 </span>

--- a/packages/strapi-design-system/src/Table/__tests__/Table.spec.js
+++ b/packages/strapi-design-system/src/Table/__tests__/Table.spec.js
@@ -553,7 +553,7 @@ describe('Table', () => {
                     class="c8"
                     tabindex="-1"
                   >
-                    <div>
+                    <span>
                       <div
                         class="c16"
                       >
@@ -565,7 +565,7 @@ describe('Table', () => {
                           width="26px"
                         />
                       </div>
-                    </div>
+                    </span>
                   </td>
                   <td
                     aria-colindex="4"
@@ -660,7 +660,7 @@ describe('Table', () => {
                     class="c8"
                     tabindex="-1"
                   >
-                    <div>
+                    <span>
                       <div
                         class="c16"
                       >
@@ -672,7 +672,7 @@ describe('Table', () => {
                           width="26px"
                         />
                       </div>
-                    </div>
+                    </span>
                   </td>
                   <td
                     aria-colindex="4"

--- a/packages/strapi-design-system/src/Table/__tests__/Table.spec.js
+++ b/packages/strapi-design-system/src/Table/__tests__/Table.spec.js
@@ -365,8 +365,6 @@ describe('Table', () => {
       .c16 {
         border-radius: 50%;
         display: block;
-        height: 26px;
-        width: 26px;
       }
 
       .c17 {
@@ -548,13 +546,15 @@ describe('Table', () => {
                     class="c8"
                     tabindex="-1"
                   >
-                    <img
-                      alt="Leon Lafrite"
-                      class="c16"
-                      height="26px"
-                      src="https://avatars.githubusercontent.com/u/3874873?v=4"
-                      width="26px"
-                    />
+                    <span>
+                      <img
+                        alt="Leon Lafrite"
+                        class="c16"
+                        height="26px"
+                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
+                        width="26px"
+                      />
+                    </span>
                   </td>
                   <td
                     aria-colindex="4"
@@ -649,13 +649,15 @@ describe('Table', () => {
                     class="c8"
                     tabindex="-1"
                   >
-                    <img
-                      alt="Leon Lafrite"
-                      class="c16"
-                      height="26px"
-                      src="https://avatars.githubusercontent.com/u/3874873?v=4"
-                      width="26px"
-                    />
+                    <span>
+                      <img
+                        alt="Leon Lafrite"
+                        class="c16"
+                        height="26px"
+                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
+                        width="26px"
+                      />
+                    </span>
                   </td>
                   <td
                     aria-colindex="4"

--- a/packages/strapi-design-system/src/Table/__tests__/Table.spec.js
+++ b/packages/strapi-design-system/src/Table/__tests__/Table.spec.js
@@ -370,6 +370,8 @@ describe('Table', () => {
 
       .c16 {
         position: relative;
+        width: 26px;
+        height: 26px;
       }
 
       .c18 {


### PR DESCRIPTION
# Avatar

## Description

Add the possibility to display a "bigger" picture when hovering an avatar

## Demo

Example on : https://design-system-git-avatar-zoom-strapijs.vercel.app/?path=/story/design-system-atoms-avatar--base

## API

```diff
<Avatar
  src="https://avatars.githubusercontent.com/u/3874873?v=4"
  alt="marvin frachet"
+  preview="https://some-unknown-photo/x.png"
/>
```

or the following when the image is the same

```diff
<Avatar
  src="https://avatars.githubusercontent.com/u/3874873?v=4"
  alt="marvin frachet"
+  preview
/>
```
