### PR TITLE
Card asset size

### DIFF
--- a/packages/strapi-design-system/src/Card/CardAsset.js
+++ b/packages/strapi-design-system/src/Card/CardAsset.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import PropTypes from 'prop-types';
 
 const CardAssetImg = styled.img`
   // inline flows is based on typography and displays an extra white space below the image
@@ -10,19 +11,32 @@ const CardAssetImg = styled.img`
   height: 100%;
 `;
 
+const CardAssetSizes = {
+  S: 88,
+  M: 164,
+};
+
 const CardAssetWrapper = styled.div`
   display: flex;
   justify-content: center;
-  height: ${88 / 16}rem;
+  height: ${({ size }) => CardAssetSizes[size] / 16}rem;
   width: 100%;
   background: repeating-conic-gradient(${({ theme }) => theme.colors.neutral100} 0% 25%, transparent 0% 50%) 50% / 20px
     20px;
 `;
 
-export const CardAsset = (props) => {
+export const CardAsset = ({ size, ...props }) => {
   return (
-    <CardAssetWrapper>
+    <CardAssetWrapper size={size}>
       <CardAssetImg {...props} aria-hidden />
     </CardAssetWrapper>
   );
+};
+
+CardAsset.defaultProps = {
+  size: 'M',
+};
+
+CardAsset.propTypes = {
+  size: PropTypes.oneOf(['S', 'M']),
 };

--- a/packages/strapi-design-system/src/Card/__tests__/Card.spec.js
+++ b/packages/strapi-design-system/src/Card/__tests__/Card.spec.js
@@ -196,7 +196,7 @@ describe('Card', () => {
         -webkit-justify-content: center;
         -ms-flex-pack: center;
         justify-content: center;
-        height: 5.5rem;
+        height: 10.25rem;
         width: 100%;
         background: repeating-conic-gradient(#f6f6f9 0% 25%,transparent 0% 50%) 50% / 20px 20px;
       }


### PR DESCRIPTION
# CardAsset

## Description

Allow CardAsset to receive a size (S or M) in order to display it in the good context

## Demo

Example on : [deployed story link]

## API

```diff
<Card style={{ width: '240px' }} id="first">
  <CardHeader>
    <CardCheckbox value={true} />
    <CardAction position="end">
      <IconButton title="Edit the thing">
        <EditIcon />
      </IconButton>
    </CardAction>
+    <CardAsset src={firstImgPath} size="S" /> {/* or M (default value) */}
    <CardTimer>05:39</CardTimer>
  </CardHeader>
  <CardBody>
    <CardContent>
      <CardTitle>File name</CardTitle>
      <CardSubtitle>PNG - 400✕400</CardSubtitle>
    </CardContent>
    <CardBadge>Doc</CardBadge>
  </CardBody>
</Card>
```

## Screenshot

<img width="1280" alt="Strapi's media library" src="https://user-images.githubusercontent.com/3874873/126614369-fc43458e-8f33-4b29-8696-3cd7aff42405.png">
